### PR TITLE
Align README and older guide docs with current surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # TurboQuant-native Vector Database
 
-**Store billions of embeddings with 4× lower memory while keeping >95% recall and sub-100 ms query latency.**
+An early vector-database prototype exploring TurboQuant-style compressed retrieval, hybrid mutable/sealed execution, reranking, benchmarkable storage-engine ideas, and diagnostics-rich API surfaces.
 
-The *first* full vector database built directly on Google's brand-new [TurboQuant](https://arxiv.org/abs/2504.19874) (ICLR 2026) — the same technique that's blowing up for KV-cache compression, now applied natively to retrieval.
+## Start here
 
-![Hero benchmark chart coming soon — run the scripts below and screenshot it!]
+If you want the clearest path through the repo, read these first:
 
-## Why this matters
-- **TurboQuant-native compression** — data-oblivious, near-zero indexing time, state-of-the-art distortion
-- **Hybrid query engine** — exact path + compressed path + reranker (maximum recall safety net)
-- **Production-ready storage skeleton** — WAL + mutable buffer + sealed segments + crash recovery
-- **Already runnable** — local facade, FastAPI endpoint, full benchmarks, diagnostics exporters
+- `docs/repository-status.md`
+- `docs/current-surfaces.md`
+- `docs/benchmark-proof-pack.md`
 
-## 30-second quick start
+## Best current surfaces
+
+- **Best local facade:** `turboquant_db.showcase.ShowcaseScoredDatabase`
+- **Best API entrypoint:** `src/turboquant_db/api/app_best.py`
+- **Best benchmark workflow:** `python scripts/run_canonical_flow.py`
+- **Best report export:** `python scripts/export_full_ladder.py`
+- **Best compact proof artifact:** `python scripts/export_proof_pack.py`
+
+## Quick start
 
 ```bash
 # 1. Clone & install
@@ -20,10 +26,23 @@ git clone https://github.com/mattjanssens1/TurboQuant-native-vector-database.git
 cd TurboQuant-native-vector-database
 pip install -e .[dev]
 
-# 2. Run the showcase (best local surface)
+# 2. Run the showcase example
 python examples/quickstart.py
 
-# 3. See the magic
-python scripts/run_showcase_benchmark.py          # hybrid vs exact
-python scripts/run_quantizer_comparison.py       # TurboQuant-style vs baselines
-python scripts/run_extended_benchmark.py         # full diagnostics
+# 3. Run the canonical benchmark flow
+python scripts/run_canonical_flow.py
+
+# 4. Export one compact proof table
+python scripts/export_proof_pack.py
+```
+
+## What this repo is trying to prove
+
+- hybrid query execution across mutable and sealed state can be made coherent
+- compressed retrieval can be benchmarked honestly against exact and reranked paths
+- diagnostics-rich APIs are useful during engine development
+- a small local storage engine can support meaningful benchmark and architecture work
+
+## Important note on TurboQuant wording
+
+This repo includes TurboQuant-style and adapter-based work, but not a claim of full algorithmic fidelity. Where code is experimental or placeholder, it should be read that way.

--- a/docs/canonical-path.md
+++ b/docs/canonical-path.md
@@ -8,43 +8,44 @@ Use:
 
 - `turboquant_db.showcase.ShowcaseScoredDatabase`
 
-This is the current best local development surface because it supports:
+This is still the clearest local development surface for:
 
 - hybrid queries over mutable and sealed data
 - scored hits with metadata
 - reranked compressed queries
-- benchmark-friendly behavior
+- benchmark-oriented local runs
 
 ## Best API surface
 
 Use:
 
-- `src/turboquant_db/api/showcase_server_traced.py`
+- `src/turboquant_db/api/app_best.py`
+- `python scripts/run_best_api.py`
 
-This is the current best public-facing API because it returns:
-
-- scored results
-- metadata
-- trace diagnostics
-- exact, compressed, and reranked query modes
+Treat narrower API variants as experimental unless a newer doc explicitly blesses them.
 
 ## Best benchmark entrypoints
 
 Use:
 
-- `scripts/run_showcase_benchmark.py`
-- `scripts/run_quantizer_comparison.py`
-- `scripts/run_extended_benchmark.py`
-- `scripts/export_benchmark_diagnostics.py`
+- `python scripts/run_canonical_flow.py`
+- `python scripts/export_full_ladder.py`
+- `python scripts/export_proof_pack.py`
+
+Use the proof-pack export when you want one compact, reproducible benchmark artifact.
 
 ## Best example
 
 Use:
 
-- `examples/quickstart.py`
+- `python examples/quickstart.py`
+
+## Read these next
+
+- `docs/current-surfaces.md`
+- `docs/repository-status.md`
+- `docs/benchmark-proof-pack.md`
 
 ## Why this file exists
 
-There are a few thinner or earlier modules in the repository from the project’s evolution.
-
-This file marks the current highest-signal path so contributors and visitors do not have to guess which route is the most representative.
+Older modules and docs still exist from the repo's evolution. This file marks the current highest-signal path so contributors and visitors do not have to guess which route is most representative.

--- a/docs/public-surface.md
+++ b/docs/public-surface.md
@@ -5,12 +5,14 @@ This file lists the current best surfaces to use when you want the repository to
 ## Best API to run
 
 ```bash
-python scripts/run_observed_api.py
+python scripts/run_best_api.py
 ```
 
-This runs the current best public-facing API:
+This runs the current best public-facing API entrypoint:
 
-- `src/turboquant_db/api/app_observed.py`
+- `src/turboquant_db/api/app_best.py`
+
+Treat other API variants as narrower or more experimental unless a newer doc says otherwise.
 
 ## Best local code API
 
@@ -18,26 +20,25 @@ Use:
 
 - `turboquant_db.showcase.ShowcaseScoredDatabase`
 
-## Best benchmark scripts
+## Best benchmark commands
 
 Use these in order:
 
 ```bash
-python scripts/run_showcase_benchmark.py
-python scripts/run_quantizer_comparison.py
-python scripts/run_extended_benchmark.py
-python scripts/export_showcase_bundle.py
-python scripts/export_quantizer_bundle.py
-python scripts/export_extended_diagnostics.py
+python scripts/run_canonical_flow.py
+python scripts/export_full_ladder.py
+python scripts/export_proof_pack.py
 ```
+
+Use the proof-pack export when you want one compact, reproducible artifact instead of the broader report bundle.
 
 ## Best docs to read next
 
-- `docs/start-here.md`
-- `docs/canonical-path.md`
-- `docs/benchmark-guide.md`
+- `docs/current-surfaces.md`
+- `docs/repository-status.md`
+- `docs/benchmark-proof-pack.md`
 - `docs/legacy-paths.md`
 
 ## Why this exists
 
-The repo now has enough working surfaces that a concise map is more useful than another architecture essay.
+The repo has multiple runnable surfaces from its evolution. This file is meant to point readers at the current best entrypoints without making them reverse-engineer the history.


### PR DESCRIPTION
## Summary
- update `README.md` to point readers at the newer status, surfaces, and proof-pack docs
- update `docs/canonical-path.md` to use `app_best` and the current benchmark/report entrypoints
- update `docs/public-surface.md` so it no longer points at older observed API paths

## Why
The newer docs now tell a clearer and more honest story, but some older outward-facing files still point at stale API surfaces and older benchmark commands. This PR aligns those older signposts with the newer source-of-truth docs.

## Scope
Docs-only. No engine or benchmark logic changes.
