### PR TITLE
Clarify API surface policy

### DIFF
--- a/docs/api-surface-policy.md
+++ b/docs/api-surface-policy.md
@@ -1,0 +1,38 @@
+# API Surface Policy
+
+This repository currently keeps multiple API entrypoints for compatibility and experimentation.
+
+## Canonical public entrypoint
+
+Use:
+
+- `src/turboquant_db/api/app_best.py`
+- `python scripts/run_best_api.py`
+
+This is the default public-facing API path for new usage.
+
+## Compatibility alias
+
+Use only when older notes or scripts already point at it:
+
+- `src/turboquant_db/api/app_observed.py`
+- `python scripts/run_observed_api.py`
+
+These names currently exist for compatibility and intentionally resolve to the same surface as `app_best.py`.
+
+## Experimental inspection surfaces
+
+Use when you specifically want richer or more specialized diagnostics:
+
+- `src/turboquant_db/api/app_inspected.py`
+- `src/turboquant_db/api/app_measured.py`
+
+These are useful during engine development, but they are not the default public entrypoint.
+
+## Internal server modules
+
+Files named `showcase_server_*` are implementation modules behind the higher-level `app_*` entrypoints. They are real code, but they should be treated as lower-level surfaces when deciding what to link in docs.
+
+## Why this file exists
+
+The repo has grown a few surface names as the prototype evolved. This file is here to make the intended hierarchy explicit until a future consolidation pass removes or retires more aliases.

--- a/docs/current-surfaces.md
+++ b/docs/current-surfaces.md
@@ -22,7 +22,9 @@ Use:
 - `src/turboquant_db/api/app_best.py`
 - `python scripts/run_best_api.py`
 
-Treat other API variants as narrower or more experimental unless a newer doc says otherwise.
+Use `app_observed.py` and `run_observed_api.py` only as compatibility aliases for older notes and scripts.
+
+Use `app_inspected.py` and `app_measured.py` when you explicitly want narrower experimental inspection surfaces.
 
 ## Best benchmark flow
 
@@ -40,12 +42,26 @@ Use:
 
 This is the broadest export path for the current benchmark ladder.
 
+## Best compact proof artifact
+
+Use:
+
+- `python scripts/export_proof_pack.py`
+
+Use this when you want one small, reproducible benchmark artifact.
+
 ## Best example
 
 Use:
 
 - `python examples/quickstart.py`
 
+## Read these next
+
+- `docs/api-surface-policy.md`
+- `docs/repository-status.md`
+- `docs/benchmark-proof-pack.md`
+
 ## Why this file exists
 
-Some older docs point at earlier API surfaces from the repo's evolution. This file is meant to be the singular "start here" map until those older docs are tightened.
+Some older docs and surface names still exist from the repo's evolution. This file is meant to be the singular "start here" map until a future consolidation pass removes more aliases.

--- a/scripts/run_observed_api.py
+++ b/scripts/run_observed_api.py
@@ -1,4 +1,10 @@
-from turboquant_db.api.app_observed import app
+"""Compatibility runner for the legacy observed API name.
+
+Prefer ``scripts/run_best_api.py`` for new usage. This runner stays in place so
+older notes and commands continue to work.
+"""
+
+from turboquant_db.api.app_best import app
 
 
 if __name__ == "__main__":

--- a/src/turboquant_db/api/app_observed.py
+++ b/src/turboquant_db/api/app_observed.py
@@ -1,6 +1,9 @@
-from turboquant_db.api.showcase_server_observed_plus import app, create_observed_plus_showcase_app
+"""Compatibility alias for the current best API surface.
 
-create_app = create_observed_plus_showcase_app
+Use ``app_best.py`` for new entrypoints. This module remains so older scripts and
+links can keep working while both names still resolve to the same surface.
+"""
+
+from turboquant_db.api.app_best import app, create_app
 
 __all__ = ["app", "create_app"]
-


### PR DESCRIPTION
## Summary
- make app_observed.py a compatibility alias to app_best.py
- make run_observed_api.py a compatibility runner that points at the best surface
- add docs/api-surface-policy.md
- update docs/current-surfaces.md

## Why
This is a small consolidation pass that makes the API hierarchy more explicit without removing compatibility entrypoints.
