### PR TITLE
Add soft deprecation labels for legacy API surfaces

### DIFF
--- a/docs/api-surface-policy.md
+++ b/docs/api-surface-policy.md
@@ -11,14 +11,14 @@ Use:
 
 This is the default public-facing API path for new usage.
 
-## Compatibility alias
+## Compatibility alias (soft-deprecated)
 
 Use only when older notes or scripts already point at it:
 
 - `src/turboquant_db/api/app_observed.py`
 - `python scripts/run_observed_api.py`
 
-These names currently exist for compatibility and intentionally resolve to the same surface as `app_best.py`.
+These names intentionally resolve to the same surface as `app_best.py`. They remain available during a soft-deprecation window, but new docs, examples, and commands should use the canonical `best` names instead.
 
 ## Experimental inspection surfaces
 
@@ -27,7 +27,7 @@ Use when you specifically want richer or more specialized diagnostics:
 - `src/turboquant_db/api/app_inspected.py`
 - `src/turboquant_db/api/app_measured.py`
 
-These are useful during engine development, but they are not the default public entrypoint.
+These are useful during engine development, but they are not the default public entrypoint and may change faster than the canonical surface.
 
 ## Internal server modules
 

--- a/docs/current-surfaces.md
+++ b/docs/current-surfaces.md
@@ -22,7 +22,7 @@ Use:
 - `src/turboquant_db/api/app_best.py`
 - `python scripts/run_best_api.py`
 
-Use `app_observed.py` and `run_observed_api.py` only as compatibility aliases for older notes and scripts.
+Use `app_observed.py` and `run_observed_api.py` only as soft-deprecated compatibility aliases for older notes and scripts.
 
 Use `app_inspected.py` and `app_measured.py` when you explicitly want narrower experimental inspection surfaces.
 
@@ -59,6 +59,7 @@ Use:
 ## Read these next
 
 - `docs/api-surface-policy.md`
+- `docs/deprecations.md`
 - `docs/repository-status.md`
 - `docs/benchmark-proof-pack.md`
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,38 @@
+# Deprecations
+
+This file tracks **soft deprecations** for public-facing names in the repository.
+
+## Soft-deprecated compatibility aliases
+
+These names still work, but new docs, examples, and commands should prefer the canonical replacements.
+
+### API module alias
+
+Prefer:
+
+- `src/turboquant_db/api/app_best.py`
+
+Instead of:
+
+- `src/turboquant_db/api/app_observed.py`
+
+### Runner alias
+
+Prefer:
+
+- `python scripts/run_best_api.py`
+
+Instead of:
+
+- `python scripts/run_observed_api.py`
+
+## Experimental but not deprecated
+
+These surfaces are still valid for targeted engine work, but they are not the default public path:
+
+- `src/turboquant_db/api/app_inspected.py`
+- `src/turboquant_db/api/app_measured.py`
+
+## Removal policy
+
+There is no forced removal date yet. These aliases remain available so older notes and commands keep working while the repo continues to consolidate around fewer stronger surfaces.

--- a/docs/legacy-paths.md
+++ b/docs/legacy-paths.md
@@ -8,10 +8,20 @@ This repository evolved quickly, so a few thinner or earlier modules still exist
 
 Prefer:
 
-- `src/turboquant_db/api/app_observed.py`
-- `src/turboquant_db/api/showcase_server_observed.py`
+- `src/turboquant_db/api/app_best.py`
+- `python scripts/run_best_api.py`
 
-Older traced or showcase API modules may still be useful for reference, but the observed path is the best public-facing surface right now.
+Compatibility aliases still exist for older notes and scripts:
+
+- `src/turboquant_db/api/app_observed.py`
+- `python scripts/run_observed_api.py`
+
+### Experimental inspection surfaces
+
+Use these only when you specifically want richer or more specialized diagnostics:
+
+- `src/turboquant_db/api/app_inspected.py`
+- `src/turboquant_db/api/app_measured.py`
 
 ### Local database facade
 
@@ -23,12 +33,12 @@ Prefer:
 
 Prefer:
 
-- `src/turboquant_db/benchmark/showcase_runner.py`
-- `src/turboquant_db/benchmark/extended_runner.py`
-- `src/turboquant_db/benchmark/quantizer_compare.py`
+- `python scripts/run_canonical_flow.py`
+- `python scripts/export_full_ladder.py`
+- `python scripts/export_proof_pack.py`
 
 ### Why this matters
 
-New contributors should not have to infer which path is the current best path from file names alone.
+New contributors should not have to infer which path is current from file names alone.
 
-Use `docs/start-here.md` first, then `docs/canonical-path.md`, then this file if you want context on why multiple parallel modules exist.
+Use `docs/current-surfaces.md` first, then `docs/api-surface-policy.md`, then this file if you want context on why multiple parallel modules still exist.

--- a/scripts/run_observed_api.py
+++ b/scripts/run_observed_api.py
@@ -1,7 +1,7 @@
-"""Compatibility runner for the legacy observed API name.
+"""Soft-deprecated compatibility runner for the legacy observed API name.
 
 Prefer ``scripts/run_best_api.py`` for new usage. This runner stays in place so
-older notes and commands continue to work.
+older notes and commands continue to work during the deprecation window.
 """
 
 from turboquant_db.api.app_best import app

--- a/src/turboquant_db/api/app_inspected.py
+++ b/src/turboquant_db/api/app_inspected.py
@@ -1,3 +1,10 @@
+"""Experimental inspection surface.
+
+Prefer ``app_best.py`` for default public usage. This module remains available
+for engine-focused inspection work and may change faster than the canonical
+surface.
+"""
+
 from turboquant_db.api.showcase_server_inspected import app, create_inspected_showcase_app
 
 create_app = create_inspected_showcase_app

--- a/src/turboquant_db/api/app_measured.py
+++ b/src/turboquant_db/api/app_measured.py
@@ -1,3 +1,10 @@
+"""Experimental measured inspection surface.
+
+Prefer ``app_best.py`` for default public usage. This module remains available
+for engine-focused measured inspection work and may change faster than the
+canonical surface.
+"""
+
 from turboquant_db.api.showcase_server_measured import app, create_measured_showcase_app
 
 create_app = create_measured_showcase_app

--- a/src/turboquant_db/api/app_observed.py
+++ b/src/turboquant_db/api/app_observed.py
@@ -1,7 +1,7 @@
-"""Compatibility alias for the current best API surface.
+"""Soft-deprecated compatibility alias for the current best API surface.
 
-Use ``app_best.py`` for new entrypoints. This module remains so older scripts and
-links can keep working while both names still resolve to the same surface.
+Prefer ``app_best.py`` for all new entrypoints. This module remains only so
+older scripts and links keep working during the deprecation window.
 """
 
 from turboquant_db.api.app_best import app, create_app


### PR DESCRIPTION
## Summary
- mark `app_observed.py` and `run_observed_api.py` as soft-deprecated compatibility aliases
- mark `app_inspected.py` and `app_measured.py` as experimental inspection surfaces
- add `docs/deprecations.md`
- update `docs/api-surface-policy.md`, `docs/current-surfaces.md`, and `docs/legacy-paths.md`

## Why
The repo now has a clearer canonical API path, but a deprecation pass helps reduce surface sprawl without breaking older commands or notes. This PR makes the hierarchy explicit: canonical, compatibility alias, and experimental.

## Scope
Soft deprecations only. No removals or engine behavior changes.
