### PR TITLE
Add active deprecation warnings for observed API aliases

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -26,6 +26,10 @@ Instead of:
 
 - `python scripts/run_observed_api.py`
 
+## Active deprecation signals
+
+The compatibility alias module and runner now emit `DeprecationWarning` signals to make legacy usage visible without breaking it.
+
 ## Experimental but not deprecated
 
 These surfaces are still valid for targeted engine work, but they are not the default public path:
@@ -35,4 +39,6 @@ These surfaces are still valid for targeted engine work, but they are not the de
 
 ## Removal policy
 
-There is no forced removal date yet. These aliases remain available so older notes and commands keep working while the repo continues to consolidate around fewer stronger surfaces.
+There is still no forced removal date yet. These aliases remain available so older notes and commands keep working while the repo continues to consolidate around fewer stronger surfaces.
+
+A future removal-oriented pass should only delete them after the canonical `best` surface has remained stable through multiple merge cycles and after the remaining docs no longer point at the old names.

--- a/scripts/run_observed_api.py
+++ b/scripts/run_observed_api.py
@@ -4,10 +4,17 @@ Prefer ``scripts/run_best_api.py`` for new usage. This runner stays in place so
 older notes and commands continue to work during the deprecation window.
 """
 
+import warnings
+
 from turboquant_db.api.app_best import app
 
 
 if __name__ == "__main__":
+    warnings.warn(
+        "run_observed_api.py is a soft-deprecated compatibility runner; prefer scripts/run_best_api.py.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     import uvicorn
 
     uvicorn.run(app, host="127.0.0.1", port=8001)

--- a/src/turboquant_db/api/app_observed.py
+++ b/src/turboquant_db/api/app_observed.py
@@ -4,6 +4,14 @@ Prefer ``app_best.py`` for all new entrypoints. This module remains only so
 older scripts and links keep working during the deprecation window.
 """
 
+import warnings
+
+warnings.warn(
+    "app_observed.py is a soft-deprecated compatibility alias; prefer app_best.py for new entrypoints.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from turboquant_db.api.app_best import app, create_app
 
 __all__ = ["app", "create_app"]

--- a/tests/unit/test_app_observed_deprecation.py
+++ b/tests/unit/test_app_observed_deprecation.py
@@ -1,0 +1,12 @@
+import importlib
+import warnings
+
+
+def test_app_observed_emits_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        import turboquant_db.api.app_observed as module
+        importlib.reload(module)
+
+    messages = [str(item.message) for item in caught]
+    assert any("app_observed.py is a soft-deprecated compatibility alias" in message for message in messages)


### PR DESCRIPTION
## Summary
- emit `DeprecationWarning` from `app_observed.py`
- emit `DeprecationWarning` from `run_observed_api.py`
- add a focused unit test for the module warning
- update `docs/deprecations.md` with the new active-warning stage

## Why
The repo now has a canonical API path and a soft-deprecation policy. This PR moves one step further by making legacy alias usage visible while still preserving backwards compatibility.

## Scope
Warnings only. No removals or engine behavior changes.
