### PR TITLE
Wire query plan, stats, and trace export into inspected execution

### DIFF
--- a/src/turboquant_db/api/measured_schemas.py
+++ b/src/turboquant_db/api/measured_schemas.py
@@ -24,6 +24,7 @@ class MeasuredQueryTrace(BaseModel):
     rerank_latency_ms: float
     total_latency_ms: float
     notes: dict[str, Any] = Field(default_factory=dict)
+    exported_trace: dict[str, Any] = Field(default_factory=dict)
 
 
 class MeasuredQueryResponse(BaseModel):

--- a/src/turboquant_db/api/showcase_server_measured.py
+++ b/src/turboquant_db/api/showcase_server_measured.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from turboquant_db.api.measured_schemas import MeasuredQueryResponse, MeasuredQueryTrace
 from turboquant_db.api.schemas import QueryHit, QueryRequest, UpsertRequest
 from turboquant_db.engine.inspected_db import InspectedShowcaseDatabase
+from turboquant_db.engine.query_trace_export import build_query_trace_payload
 
 
 def create_measured_showcase_app() -> FastAPI:
@@ -47,6 +48,12 @@ def create_measured_showcase_app() -> FastAPI:
             )
 
         inspection = result.inspection
+        exported_trace = build_query_trace_payload(
+            inspection=inspection,
+            plan=result.plan,
+            stats=result.stats,
+            notes={"collection_id": db.collection_id},
+        )
         trace = MeasuredQueryTrace(
             mode=inspection.mode,
             top_k=inspection.top_k,
@@ -64,6 +71,7 @@ def create_measured_showcase_app() -> FastAPI:
             rerank_latency_ms=inspection.rerank_latency_ms,
             total_latency_ms=inspection.total_latency_ms,
             notes={"collection_id": db.collection_id},
+            exported_trace=exported_trace,
         )
         return MeasuredQueryResponse(
             results=[QueryHit(vector_id=hit.vector_id, score=hit.score, metadata=hit.metadata) for hit in result.hits],

--- a/src/turboquant_db/engine/inspected_db.py
+++ b/src/turboquant_db/engine/inspected_db.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from time import perf_counter
 from typing import Any
 
+from turboquant_db.engine.query_plan import QueryPlan, build_query_plan
+from turboquant_db.engine.query_stats import QueryStats, build_query_stats
 from turboquant_db.engine.sealed_segments import SegmentReader
 from turboquant_db.engine.showcase_scored_db import ShowcaseScoredDatabase
 from turboquant_db.filter_eval import build_filter_fn
@@ -33,6 +35,8 @@ class QueryInspection:
 class QueryInspectionResult:
     hits: list[Candidate]
     inspection: QueryInspection
+    plan: QueryPlan
+    stats: QueryStats
 
 
 @dataclass(slots=True)
@@ -93,7 +97,6 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         shard_id: str = "shard-0",
     ) -> QueryInspectionResult:
         return self._query_inspected(
-            mode="exact-hybrid-engine",
             query_vector=query_vector,
             top_k=top_k,
             filters=filters,
@@ -111,7 +114,6 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         shard_id: str = "shard-0",
     ) -> QueryInspectionResult:
         return self._query_inspected(
-            mode="compressed-hybrid-engine",
             query_vector=query_vector,
             top_k=top_k,
             filters=filters,
@@ -130,7 +132,6 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         shard_id: str = "shard-0",
     ) -> QueryInspectionResult:
         return self._query_inspected(
-            mode="compressed-reranked-hybrid-engine",
             query_vector=query_vector,
             top_k=top_k,
             filters=filters,
@@ -143,7 +144,6 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
     def _query_inspected(
         self,
         *,
-        mode: str,
         query_vector: list[float],
         top_k: int,
         filters: dict[str, Any] | None,
@@ -162,6 +162,14 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         filtered_mutable = [row for row in mutable_rows if filter_fn(row.metadata)]
         filtered_sealed = [row for row in sealed_rows if filter_fn(row.metadata)]
         post_filter_candidate_count = len(filtered_mutable) + len(filtered_sealed)
+
+        plan = build_query_plan(
+            top_k=top_k,
+            approximate=approximate,
+            rerank=rerank,
+            filters_applied=bool(filters),
+            candidate_k=candidate_k,
+        )
 
         search_start = perf_counter()
         if approximate:
@@ -214,12 +222,10 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         search_latency_ms = (perf_counter() - search_start) * 1000.0
 
         rerank_latency_ms = 0.0
-        rerank_candidate_k = None
         final_hits: list[Candidate]
         if rerank:
-            rerank_candidate_k = max(candidate_k or (top_k * 4), top_k)
             rerank_start = perf_counter()
-            candidate_ids = [candidate.vector_id for candidate in ranked[:rerank_candidate_k]]
+            candidate_ids = [candidate.vector_id for candidate in ranked[: plan.candidate_k or top_k]]
             mutable_lookup = {row.vector_id: row for row in filtered_mutable}
             sealed_lookup = {row.vector_id: row for row in filtered_sealed}
             rescored: list[Candidate] = []
@@ -242,25 +248,29 @@ class InspectedShowcaseDatabase(ShowcaseScoredDatabase):
         else:
             final_hits = ranked[:top_k]
 
-        mutable_hit_count = sum(1 for hit in final_hits if source_map.get(hit.vector_id) == "mutable")
-        sealed_hit_count = sum(1 for hit in final_hits if source_map.get(hit.vector_id) == "sealed")
+        stats = build_query_stats(
+            result_ids=[hit.vector_id for hit in final_hits],
+            source_by_vector_id=source_map,
+            pre_filter_candidate_count=pre_filter_candidate_count,
+            post_filter_candidate_count=post_filter_candidate_count,
+        )
         total_latency_ms = (perf_counter() - total_start) * 1000.0
 
         inspection = QueryInspection(
-            mode=mode,
+            mode=f"{plan.mode}-engine",
             top_k=top_k,
-            filters_applied=bool(filters),
+            filters_applied=plan.filters_applied,
             mutable_live_count=len(mutable_rows),
             sealed_segment_count=len(sealed_segment_ids),
             sealed_segment_ids=sealed_segment_ids,
             result_count=len(final_hits),
-            mutable_hit_count=mutable_hit_count,
-            sealed_hit_count=sealed_hit_count,
-            pre_filter_candidate_count=pre_filter_candidate_count,
-            post_filter_candidate_count=post_filter_candidate_count,
-            rerank_candidate_k=rerank_candidate_k,
+            mutable_hit_count=stats.mutable_hit_count,
+            sealed_hit_count=stats.sealed_hit_count,
+            pre_filter_candidate_count=stats.pre_filter_candidate_count,
+            post_filter_candidate_count=stats.post_filter_candidate_count,
+            rerank_candidate_k=plan.candidate_k,
             search_latency_ms=search_latency_ms,
             rerank_latency_ms=rerank_latency_ms,
             total_latency_ms=total_latency_ms,
         )
-        return QueryInspectionResult(hits=final_hits, inspection=inspection)
+        return QueryInspectionResult(hits=final_hits, inspection=inspection, plan=plan, stats=stats)

--- a/tests/unit/test_inspected_db.py
+++ b/tests/unit/test_inspected_db.py
@@ -16,10 +16,15 @@ def test_inspected_db_returns_real_counts_for_mixed_mutable_and_sealed_hits(tmp_
     )
 
     assert result.hits
+    assert result.plan.mode == "compressed-reranked-hybrid"
+    assert result.plan.candidate_k == 8
     assert result.inspection.pre_filter_candidate_count >= 2
     assert result.inspection.post_filter_candidate_count >= 2
-    assert result.inspection.mutable_hit_count >= 0
-    assert result.inspection.sealed_hit_count >= 0
+    assert result.stats.pre_filter_candidate_count == result.inspection.pre_filter_candidate_count
+    assert result.stats.post_filter_candidate_count == result.inspection.post_filter_candidate_count
+    assert result.stats.mutable_hit_count == result.inspection.mutable_hit_count
+    assert result.stats.sealed_hit_count == result.inspection.sealed_hit_count
+    assert result.stats.mutable_hit_count + result.stats.sealed_hit_count == len(result.hits)
     assert result.inspection.total_latency_ms >= result.inspection.search_latency_ms
 
 
@@ -30,5 +35,8 @@ def test_inspected_db_exact_path_reports_zero_rerank_latency(tmp_path: Path) -> 
     result = db.query_exact_hybrid_inspected([1.0, 0.0], top_k=1)
 
     assert result.hits[0].vector_id == "a"
+    assert result.plan.mode == "exact-hybrid"
+    assert result.stats.mutable_hit_count == 1
+    assert result.stats.sealed_hit_count == 0
     assert result.inspection.rerank_candidate_k is None
     assert result.inspection.rerank_latency_ms == 0.0

--- a/tests/unit/test_measured_api.py
+++ b/tests/unit/test_measured_api.py
@@ -28,6 +28,10 @@ def test_measured_api_reports_real_candidate_counts() -> None:
     assert payload["trace"]["post_filter_candidate_count"] >= 2
     assert payload["trace"]["mutable_hit_count"] >= 1
     assert payload["trace"]["mutable_hit_count"] + payload["trace"]["sealed_hit_count"] == len(payload["results"])
+    assert payload["trace"]["exported_trace"]["inspection"]["mode"] == payload["trace"]["mode"]
+    assert payload["trace"]["exported_trace"]["plan"]["mode"] == "compressed-reranked-hybrid"
+    assert payload["trace"]["exported_trace"]["stats"]["mutable_hit_count"] == payload["trace"]["mutable_hit_count"]
+    assert payload["trace"]["exported_trace"]["notes"]["collection_id"] == "showcase-measured"
     assert payload["trace"]["total_latency_ms"] >= payload["trace"]["search_latency_ms"]
 
 
@@ -44,3 +48,4 @@ def test_measured_api_exact_mode_has_no_rerank_latency() -> None:
     assert payload["mode"] == "exact-hybrid-engine"
     assert payload["trace"]["rerank_candidate_k"] is None
     assert payload["trace"]["rerank_latency_ms"] == 0.0
+    assert payload["trace"]["exported_trace"]["plan"]["candidate_k"] is None


### PR DESCRIPTION
## Summary
- wire `build_query_plan(...)` into `InspectedShowcaseDatabase` so mode and rerank candidate normalization come from one helper
- wire `build_query_stats(...)` into inspected execution and return `plan` plus `stats` alongside the existing inspection object
- add a nested `exported_trace` payload to the measured API using `build_query_trace_payload(...)` while preserving the existing flat trace fields
- extend inspected-db and measured-api unit tests to verify helper-backed plan/stats/export parity

## Why
The engine already has reusable plan, stats, and trace-export helpers, but the live inspected/measured path was still recomputing the same ideas inline. This consolidates that logic so the measured inspection surface can expose a stable exported trace without changing the existing flat response shape.

## Scope
Focused consolidation only. No canonical `best` surface changes and no new query behavior beyond helper-backed normalization and export.

## Testing
- updated `tests/unit/test_inspected_db.py`
- updated `tests/unit/test_measured_api.py`

I did not execute the test suite from this environment, so these checks are based on targeted code-path review and patch inspection rather than a live pytest run.