### PR TITLE
feat: apply compaction retirement and active-set swaps

### DIFF
--- a/src/turboquant_db/engine/compaction_executor.py
+++ b/src/turboquant_db/engine/compaction_executor.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from turboquant_db.engine.compaction_planner import CompactionPlan, CompactionPlanner
 from turboquant_db.engine.compactor import CompactionArtifacts, LocalSegmentCompactor
+from turboquant_db.engine.manifest_validation import raise_for_manifest_issues, validate_manifest_set
+from turboquant_db.engine.retirement import apply_retirement, build_retirement_decision
 from turboquant_db.engine.segment_manifest_store import SegmentManifestStore
 from turboquant_db.model.manifest import SegmentManifest, SegmentState, ShardManifest
 
@@ -65,13 +67,28 @@ class CompactionExecutor:
             quantizer_version=quantizer_version,
             source_segment_ids=plan.candidate_segment_ids,
         )
-        artifacts.segment_manifest.state = SegmentState.SEALED
+        artifacts.segment_manifest.state = SegmentState.ACTIVE
         self.segment_manifest_store.save(artifacts.segment_manifest)
+
+        decision = build_retirement_decision(
+            current_active_segment_ids=shard_manifest.active_segment_ids,
+            replacement_segment_id=artifacts.segment_manifest.segment_id,
+            retired_segment_ids=plan.candidate_segment_ids,
+        )
+        updated_existing_manifests = apply_retirement(segment_manifests, retired_segment_ids=decision.retired_segment_ids)
+        updated_segment_manifests = [*updated_existing_manifests, artifacts.segment_manifest]
+        for manifest in updated_existing_manifests:
+            self.segment_manifest_store.save(manifest)
+
+        updated_shard_manifest = shard_manifest.model_copy(update={"active_segment_ids": decision.next_active_segment_ids})
+        issues = validate_manifest_set(shard_manifest=updated_shard_manifest, segment_manifests=updated_segment_manifests)
+        raise_for_manifest_issues(issues)
+        self.manifest_store.save(updated_shard_manifest)
 
         return CompactionExecutionResult(
             plan=plan,
             artifacts=artifacts,
-            updated_shard_manifest=shard_manifest,
-            updated_segment_manifests=[*segment_manifests, artifacts.segment_manifest],
+            updated_shard_manifest=updated_shard_manifest,
+            updated_segment_manifests=updated_segment_manifests,
             selected_source_segment_ids=list(plan.candidate_segment_ids),
         )

--- a/src/turboquant_db/engine/showcase_db.py
+++ b/src/turboquant_db/engine/showcase_db.py
@@ -18,7 +18,17 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
     """
 
     def _segment_paths(self, *, shard_id: str = "shard-0") -> list[str]:
-        return [str(path) for path in self.segment_store.list_segment_files(collection_id=self.collection_id, shard_id=shard_id)]
+        shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
+        if shard_manifest is None or not shard_manifest.active_segment_ids:
+            return [str(path) for path in self.segment_store.list_segment_files(collection_id=self.collection_id, shard_id=shard_id)]
+
+        shard_dir = Path(self.segment_store.root_dir) / self.collection_id / shard_id
+        paths: list[str] = []
+        for segment_id in shard_manifest.active_segment_ids:
+            path = shard_dir / f"{segment_id}.segment.jsonl"
+            if path.exists():
+                paths.append(str(path))
+        return paths
 
     def _query_sealed_exactish(
         self,

--- a/tests/unit/test_compaction_executor.py
+++ b/tests/unit/test_compaction_executor.py
@@ -6,10 +6,11 @@ from turboquant_db.engine.compactor import LocalSegmentCompactor
 from turboquant_db.engine.local_db import LocalVectorDatabase
 from turboquant_db.engine.manifest_store import ManifestStore
 from turboquant_db.engine.segment_manifest_store import SegmentManifestStore
+from turboquant_db.engine.showcase_db import ShowcaseLocalDatabase
 from turboquant_db.model.manifest import SegmentState, ShardManifest
 
 
-def test_compaction_executor_creates_replacement_manifest_without_retiring_sources(tmp_path: Path) -> None:
+def test_compaction_executor_retires_sources_and_updates_active_segments(tmp_path: Path) -> None:
     db = LocalVectorDatabase(collection_id='documents', root_dir=tmp_path)
     db.upsert(vector_id='a', embedding=[1.0, 0.0], metadata={'region': 'us'})
     db.flush_mutable(segment_id='seg-1', generation=1)
@@ -34,15 +35,26 @@ def test_compaction_executor_creates_replacement_manifest_without_retiring_sourc
     )
 
     assert result is not None
-    assert result.updated_shard_manifest.active_segment_ids == ['seg-1', 'seg-2']
+    assert result.updated_shard_manifest.active_segment_ids == ['seg-merged']
     assert result.selected_source_segment_ids == ['seg-1', 'seg-2']
-    assert result.artifacts.source_segment_ids == ['seg-1', 'seg-2']
     states = {manifest.segment_id: manifest.state for manifest in result.updated_segment_manifests}
-    assert states['seg-1'] == SegmentState.ACTIVE
-    assert states['seg-2'] == SegmentState.ACTIVE
-    assert states['seg-merged'] == SegmentState.SEALED
-    assert result.artifacts.segment_path.exists()
-    assert result.artifacts.manifest_path.exists()
+    assert states['seg-1'] == SegmentState.RETIRED
+    assert states['seg-2'] == SegmentState.RETIRED
+    assert states['seg-merged'] == SegmentState.ACTIVE
+
+    stored_shard = ManifestStore(tmp_path / 'manifests').load(collection_id='documents', shard_id='shard-0')
+    assert stored_shard is not None
+    assert stored_shard.active_segment_ids == ['seg-merged']
+
+    stored_segment_manifests = SegmentManifestStore(tmp_path / 'segment-manifests').list_manifests(
+        collection_id='documents', shard_id='shard-0'
+    )
+    stored_states = {manifest.segment_id: manifest.state for manifest in stored_segment_manifests}
+    assert stored_states == {
+        'seg-1': SegmentState.RETIRED,
+        'seg-2': SegmentState.RETIRED,
+        'seg-merged': SegmentState.ACTIVE,
+    }
 
 
 def test_compaction_executor_returns_none_when_not_enough_candidates(tmp_path: Path) -> None:
@@ -60,3 +72,30 @@ def test_compaction_executor_returns_none_when_not_enough_candidates(tmp_path: P
     result = executor.compact_shard(collection_id='documents', shard_id='shard-0', output_segment_id='seg-merged', generation=2)
 
     assert result is None
+
+
+def test_post_compaction_queries_use_new_active_segment_set(tmp_path: Path) -> None:
+    db = ShowcaseLocalDatabase(collection_id='documents', root_dir=tmp_path)
+    db.upsert(vector_id='a', embedding=[1.0, 0.0], metadata={'region': 'us'})
+    db.flush_mutable(segment_id='seg-1', generation=1)
+    db.upsert(vector_id='b', embedding=[0.0, 1.0], metadata={'region': 'ca'})
+    db.flush_mutable(segment_id='seg-2', generation=2)
+    ManifestStore(tmp_path / 'manifests').save(
+        ShardManifest(shard_id='shard-0', collection_id='documents', active_segment_ids=['seg-1', 'seg-2'])
+    )
+
+    executor = CompactionExecutor(
+        planner=CompactionPlanner(min_segment_count=2, max_total_rows=10),
+        compactor=LocalSegmentCompactor(segments_root=tmp_path / 'segments', manifests_root=tmp_path / 'manifests'),
+        manifest_store=ManifestStore(tmp_path / 'manifests'),
+        segment_manifest_store=SegmentManifestStore(tmp_path / 'segment-manifests'),
+    )
+    result = executor.compact_shard(
+        collection_id='documents',
+        shard_id='shard-0',
+        output_segment_id='seg-merged',
+        generation=3,
+    )
+
+    assert result is not None
+    assert db.query_exact_hybrid([1.0, 0.0], top_k=2)[:2] == ['a', 'b']


### PR DESCRIPTION
## Summary
Make compaction results become live shard state.

Complete the compaction lifecycle transition by retiring replaced source segments, activating the replacement segment, and updating shard active state.

## Why
A replacement segment alone is not enough. After compaction, the engine needs to explicitly retire the replaced sources and point reads at the new active segment set.

## What changed
- Wired compaction flow through:
  - `build_retirement_decision(...)`
  - `apply_retirement(...)`
- Persisted retired source segment manifests
- Marked the replacement segment active
- Updated shard manifest `active_segment_ids`
- Made query/read paths honor shard active-set state after compaction

## Testing
- `pytest tests/unit/test_compaction_executor.py tests/unit/test_compactor.py tests/unit/test_retirement.py tests/unit/test_showcase_db.py tests/unit/test_inspected_db.py tests/unit/test_manifest_validation.py`
- **17 passed**

## Notes
This is the lifecycle transition slice: compaction output now becomes live engine state.

Known follow-up seam:
- `LocalVectorDatabase.flush_mutable()` still tends to collapse shard active state to a single segment, so naturally produced multi-active lifecycle behavior is still weaker than these explicit compaction tests imply.
- That is a consistency follow-up, not a blocker for this PR.
