### PR TITLE
feat: add explicit retired-segment garbage collection

### DIFF
--- a/src/turboquant_db/engine/local_db.py
+++ b/src/turboquant_db/engine/local_db.py
@@ -8,6 +8,7 @@ from turboquant_db.engine.mutable_buffer import MutableBuffer
 from turboquant_db.engine.query_executor import QueryExecutor
 from turboquant_db.engine.recovery_manager import RecoveryManager
 from turboquant_db.engine.sealed_segments import LocalSegmentStore, SegmentBuilder
+from turboquant_db.engine.segment_gc_executor import SegmentGarbageCollectionExecution, SegmentGarbageCollectionExecutor
 from turboquant_db.engine.segment_manifest_store import SegmentManifestStore
 from turboquant_db.engine.write_log import WriteLog
 from turboquant_db.model.manifest import SegmentState, ShardManifest
@@ -119,6 +120,14 @@ class LocalVectorDatabase:
             issues = validate_manifest_set(shard_manifest=shard_manifest, segment_manifests=segment_manifests)
             raise_for_manifest_issues(issues)
         return shard_manifest, segment_manifests
+
+    def collect_retired_segments(self, *, shard_id: str = "shard-0") -> SegmentGarbageCollectionExecution:
+        executor = SegmentGarbageCollectionExecutor(
+            segment_manifest_store=self.segment_manifest_store,
+            segments_root=self.root_dir / "segments",
+            manifests_root=self.root_dir / "manifests",
+        )
+        return executor.collect_shard(collection_id=self.collection_id, shard_id=shard_id)
 
     def recover(self) -> int:
         applied = self.recovery_manager.replay(

--- a/src/turboquant_db/engine/segment_gc.py
+++ b/src/turboquant_db/engine/segment_gc.py
@@ -8,7 +8,7 @@ from turboquant_db.model.manifest import SegmentManifest, SegmentState
 class SegmentGarbageCandidate:
     segment_id: str
     segment_path: Path
-    manifest_path: Path
+    manifest_paths: list[Path]
 
 
 @dataclass(slots=True)
@@ -21,18 +21,25 @@ def plan_segment_garbage_collection(
     *,
     manifests: list[SegmentManifest],
     segments_root: str | Path,
+    manifests_root: str | Path | None = None,
 ) -> list[SegmentGarbageCandidate]:
     root = Path(segments_root)
+    manifest_root = Path(manifests_root) if manifests_root is not None else None
     candidates: list[SegmentGarbageCandidate] = []
     for manifest in manifests:
         if manifest.state != SegmentState.RETIRED:
             continue
         shard_dir = root / manifest.collection_id / manifest.shard_id
+        manifest_paths = [shard_dir / f"{manifest.segment_id}.manifest.json"]
+        if manifest_root is not None:
+            extra_manifest_path = manifest_root / manifest.collection_id / manifest.shard_id / f"{manifest.segment_id}.manifest.json"
+            if extra_manifest_path not in manifest_paths:
+                manifest_paths.append(extra_manifest_path)
         candidates.append(
             SegmentGarbageCandidate(
                 segment_id=manifest.segment_id,
                 segment_path=shard_dir / f"{manifest.segment_id}.segment.jsonl",
-                manifest_path=shard_dir / f"{manifest.segment_id}.manifest.json",
+                manifest_paths=manifest_paths,
             )
         )
     return candidates
@@ -42,7 +49,7 @@ def execute_segment_garbage_collection(candidates: list[SegmentGarbageCandidate]
     removed_segment_ids: list[str] = []
     removed_paths: list[Path] = []
     for candidate in candidates:
-        for path in [candidate.segment_path, candidate.manifest_path]:
+        for path in [candidate.segment_path, *candidate.manifest_paths]:
             if path.exists():
                 path.unlink()
                 removed_paths.append(path)

--- a/src/turboquant_db/engine/segment_gc_executor.py
+++ b/src/turboquant_db/engine/segment_gc_executor.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from turboquant_db.engine.segment_gc import (
+    SegmentGarbageCollectionResult,
+    execute_segment_garbage_collection,
+    plan_segment_garbage_collection,
+)
+from turboquant_db.engine.segment_manifest_store import SegmentManifestStore
+
+
+@dataclass(slots=True)
+class SegmentGarbageCollectionExecution:
+    shard_id: str
+    collection_id: str
+    candidate_segment_ids: list[str]
+    result: SegmentGarbageCollectionResult
+
+
+class SegmentGarbageCollectionExecutor:
+    def __init__(self, *, segment_manifest_store: SegmentManifestStore, segments_root: str | Path, manifests_root: str | Path | None = None) -> None:
+        self.segment_manifest_store = segment_manifest_store
+        self.segments_root = Path(segments_root)
+        self.manifests_root = Path(manifests_root) if manifests_root is not None else None
+
+    def collect_shard(self, *, collection_id: str, shard_id: str = 'shard-0') -> SegmentGarbageCollectionExecution:
+        manifests = self.segment_manifest_store.list_manifests(collection_id=collection_id, shard_id=shard_id)
+        candidates = plan_segment_garbage_collection(
+            manifests=manifests,
+            segments_root=self.segments_root,
+            manifests_root=self.manifests_root,
+        )
+        result = execute_segment_garbage_collection(candidates)
+        return SegmentGarbageCollectionExecution(
+            shard_id=shard_id,
+            collection_id=collection_id,
+            candidate_segment_ids=[candidate.segment_id for candidate in candidates],
+            result=result,
+        )

--- a/tests/unit/test_segment_gc.py
+++ b/tests/unit/test_segment_gc.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
+from turboquant_db.engine.compaction_executor import CompactionExecutor
+from turboquant_db.engine.compaction_planner import CompactionPlanner
+from turboquant_db.engine.compactor import LocalSegmentCompactor
+from turboquant_db.engine.local_db import LocalVectorDatabase
+from turboquant_db.engine.manifest_store import ManifestStore
 from turboquant_db.engine.segment_gc import execute_segment_garbage_collection, plan_segment_garbage_collection
-from turboquant_db.model.manifest import SegmentManifest, SegmentState
+from turboquant_db.engine.segment_manifest_store import SegmentManifestStore
+from turboquant_db.model.manifest import SegmentManifest, SegmentState, ShardManifest
 
 
 def _manifest(segment_id: str, state: SegmentState) -> SegmentManifest:
@@ -24,7 +30,7 @@ def test_plan_segment_garbage_collection_returns_only_retired_segments(tmp_path:
 
     assert [candidate.segment_id for candidate in candidates] == ["seg-1"]
     assert candidates[0].segment_path == tmp_path / "documents" / "shard-0" / "seg-1.segment.jsonl"
-    assert candidates[0].manifest_path == tmp_path / "documents" / "shard-0" / "seg-1.manifest.json"
+    assert candidates[0].manifest_paths == [tmp_path / "documents" / "shard-0" / "seg-1.manifest.json"]
 
 
 def test_execute_segment_garbage_collection_removes_existing_files(tmp_path: Path) -> None:
@@ -33,11 +39,100 @@ def test_execute_segment_garbage_collection_removes_existing_files(tmp_path: Pat
         segments_root=tmp_path,
     )
     candidates[0].segment_path.parent.mkdir(parents=True, exist_ok=True)
-    candidates[0].segment_path.write_text('segment', encoding='utf-8')
-    candidates[0].manifest_path.write_text('manifest', encoding='utf-8')
+    candidates[0].segment_path.write_text("segment", encoding="utf-8")
+    candidates[0].manifest_paths[0].write_text("manifest", encoding="utf-8")
 
     result = execute_segment_garbage_collection(candidates)
 
-    assert result.removed_segment_ids == ['seg-1']
+    assert result.removed_segment_ids == ["seg-1"]
     assert not candidates[0].segment_path.exists()
-    assert not candidates[0].manifest_path.exists()
+    assert not candidates[0].manifest_paths[0].exists()
+
+
+def test_collect_retired_segments_removes_only_retired_artifacts(tmp_path: Path) -> None:
+    db = LocalVectorDatabase(collection_id="documents", root_dir=tmp_path)
+    db.upsert(vector_id="a", embedding=[1.0, 0.0], metadata={"region": "us"})
+    db.flush_mutable(segment_id="seg-1", generation=1)
+    db.upsert(vector_id="b", embedding=[0.0, 1.0], metadata={"region": "ca"})
+    db.flush_mutable(segment_id="seg-2", generation=2)
+    ManifestStore(tmp_path / "manifests").save(
+        ShardManifest(shard_id="shard-0", collection_id="documents", active_segment_ids=["seg-1", "seg-2"])
+    )
+
+    executor = CompactionExecutor(
+        planner=CompactionPlanner(min_segment_count=2, max_total_rows=10),
+        compactor=LocalSegmentCompactor(segments_root=tmp_path / "segments", manifests_root=tmp_path / "manifests"),
+        manifest_store=ManifestStore(tmp_path / "manifests"),
+        segment_manifest_store=SegmentManifestStore(tmp_path / "segment-manifests"),
+    )
+    result = executor.compact_shard(collection_id="documents", shard_id="shard-0", output_segment_id="seg-merged", generation=3)
+    assert result is not None
+
+    seg_root = tmp_path / "segments" / "documents" / "shard-0"
+    manifest_root = tmp_path / "manifests" / "documents" / "shard-0"
+    assert (seg_root / "seg-1.segment.jsonl").exists()
+    assert (seg_root / "seg-2.segment.jsonl").exists()
+    assert (seg_root / "seg-merged.segment.jsonl").exists()
+
+    gc_result = db.collect_retired_segments()
+
+    assert gc_result.candidate_segment_ids == ["seg-1", "seg-2"]
+    assert gc_result.result.removed_segment_ids == ["seg-1", "seg-2"]
+    assert not (seg_root / "seg-1.segment.jsonl").exists()
+    assert not (seg_root / "seg-2.segment.jsonl").exists()
+    assert (seg_root / "seg-merged.segment.jsonl").exists()
+    assert not (manifest_root / "seg-1.manifest.json").exists()
+    assert not (manifest_root / "seg-2.manifest.json").exists()
+    assert (manifest_root / "seg-merged.manifest.json").exists()
+
+
+def test_collect_retired_segments_removes_retired_manifests_from_both_storage_roots(tmp_path: Path) -> None:
+    db = LocalVectorDatabase(collection_id="documents", root_dir=tmp_path)
+    db.upsert(vector_id="a", embedding=[1.0, 0.0], metadata={"region": "us"})
+    db.flush_mutable(segment_id="seg-1", generation=1)
+    ManifestStore(tmp_path / "manifests").save(
+        ShardManifest(shard_id="shard-0", collection_id="documents", active_segment_ids=["seg-1"])
+    )
+
+    retired_manifest = SegmentManifestStore(tmp_path / "segment-manifests").load(
+        collection_id="documents", shard_id="shard-0", segment_id="seg-1"
+    )
+    assert retired_manifest is not None
+    SegmentManifestStore(tmp_path / "segment-manifests").save(retired_manifest.model_copy(update={"state": SegmentState.RETIRED}))
+
+    compacted_manifest_path = tmp_path / "manifests" / "documents" / "shard-0" / "seg-1.manifest.json"
+    compacted_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    compacted_manifest_path.write_text("retired-compact-manifest", encoding="utf-8")
+
+    gc_result = db.collect_retired_segments()
+
+    assert gc_result.candidate_segment_ids == ["seg-1"]
+    assert not (tmp_path / "segments" / "documents" / "shard-0" / "seg-1.segment.jsonl").exists()
+    assert not (tmp_path / "segments" / "documents" / "shard-0" / "seg-1.manifest.json").exists()
+    assert not compacted_manifest_path.exists()
+
+
+def test_collect_retired_segments_is_idempotent(tmp_path: Path) -> None:
+    db = LocalVectorDatabase(collection_id="documents", root_dir=tmp_path)
+    db.upsert(vector_id="a", embedding=[1.0, 0.0], metadata={"region": "us"})
+    db.flush_mutable(segment_id="seg-1", generation=1)
+    db.upsert(vector_id="b", embedding=[0.0, 1.0], metadata={"region": "ca"})
+    db.flush_mutable(segment_id="seg-2", generation=2)
+    ManifestStore(tmp_path / "manifests").save(
+        ShardManifest(shard_id="shard-0", collection_id="documents", active_segment_ids=["seg-1", "seg-2"])
+    )
+
+    executor = CompactionExecutor(
+        planner=CompactionPlanner(min_segment_count=2, max_total_rows=10),
+        compactor=LocalSegmentCompactor(segments_root=tmp_path / "segments", manifests_root=tmp_path / "manifests"),
+        manifest_store=ManifestStore(tmp_path / "manifests"),
+        segment_manifest_store=SegmentManifestStore(tmp_path / "segment-manifests"),
+    )
+    assert executor.compact_shard(collection_id="documents", shard_id="shard-0", output_segment_id="seg-merged", generation=3) is not None
+
+    first = db.collect_retired_segments()
+    second = db.collect_retired_segments()
+
+    assert first.result.removed_segment_ids == ["seg-1", "seg-2"]
+    assert second.result.removed_segment_ids == ["seg-1", "seg-2"]
+    assert second.result.removed_paths == []


### PR DESCRIPTION
## Summary
Finish the lifecycle with explicit retired-artifact cleanup.

Add an explicit retired-segment garbage collection executor and database entrypoint to safely clean up retired storage artifacts after compaction retirement.

## Why
The compaction lifecycle remains incomplete until retired artifacts can be explicitly cleaned up. This PR turns GC planning into a callable cleanup step.

## What changed
- Added `SegmentGarbageCollectionExecutor`
- Added `LocalVectorDatabase.collect_retired_segments()`
- Wired GC flow through `plan_segment_garbage_collection(...)`
- Deletes retired segment artifacts
- Deletes retired manifest artifacts from both storage roots used by the current model
- Repeated GC calls remain safe and no-op cleanly for already-deleted paths

## Testing
- Targeted lifecycle subset: **11 passed**
- Full unit suite: **85 passed**

## Notes
This PR includes the GC correctness fix in final form:
- retired manifests are collected from both storage roots
- replacement manifests survive cleanup
- repeated cleanup remains safe

Current behavior fully deletes retired manifest artifacts because that matches the existing storage model. If you later want tombstones or retained lifecycle history, GC policy should be revisited explicitly rather than inferred.
