### PR TITLE
feat(engine): sprint 4 — fix cache benchmark path and rerun benchmark

### DIFF
--- a/docs/benchmark-cache-sprint-4.md
+++ b/docs/benchmark-cache-sprint-4.md
@@ -1,0 +1,31 @@
+# Sprint 4 Cache Summary
+
+Representative subset: `tiny_fixture` and `clustered_fixture`, using the canonical scalar quantizer plus `normalized-scalar` as a scalar control. `TurboQuantAdapter` is intentionally excluded from the canonical table and remains experimental only.
+
+## clustered_fixture_16 / normalized-scalar-int8-127
+- `exact-hybrid`: 3.157 ms -> 0.900 ms (-2.257 ms), cache hit rate 0.882, file reads 16 -> 1, decode loads 16 -> 1.
+- `compressed-hybrid`: 4.689 ms -> 2.135 ms (-2.554 ms), cache hit rate 0.882, file reads 16 -> 1, decode loads 16 -> 1.
+- `compressed-reranked-hybrid`: 5.894 ms -> 2.471 ms (-3.423 ms), cache hit rate 0.920, file reads 24 -> 1, decode loads 24 -> 1.
+- With cache enabled, `compressed-reranked-hybrid` vs `exact-hybrid`: 2.471 ms vs 0.900 ms. `compressed-hybrid` stays at 2.135 ms.
+
+## clustered_fixture_16 / scalar-int8-127
+- `exact-hybrid`: 2.865 ms -> 0.682 ms (-2.183 ms), cache hit rate 0.882, file reads 16 -> 1, decode loads 16 -> 1.
+- `compressed-hybrid`: 3.025 ms -> 1.088 ms (-1.937 ms), cache hit rate 0.882, file reads 16 -> 1, decode loads 16 -> 1.
+- `compressed-reranked-hybrid`: 4.228 ms -> 1.313 ms (-2.915 ms), cache hit rate 0.920, file reads 24 -> 1, decode loads 24 -> 1.
+- With cache enabled, `compressed-reranked-hybrid` vs `exact-hybrid`: 1.313 ms vs 0.682 ms. `compressed-hybrid` stays at 1.088 ms.
+
+## tiny_fixture / normalized-scalar-int8-127
+- `exact-hybrid`: 0.970 ms -> 0.428 ms (-0.542 ms), cache hit rate 0.846, file reads 12 -> 1, decode loads 12 -> 1.
+- `compressed-hybrid`: 1.176 ms -> 0.562 ms (-0.614 ms), cache hit rate 0.846, file reads 12 -> 1, decode loads 12 -> 1.
+- `compressed-reranked-hybrid`: 1.719 ms -> 0.836 ms (-0.884 ms), cache hit rate 0.895, file reads 18 -> 1, decode loads 18 -> 1.
+- With cache enabled, `compressed-reranked-hybrid` vs `exact-hybrid`: 0.836 ms vs 0.428 ms. `compressed-hybrid` stays at 0.562 ms.
+
+## tiny_fixture / scalar-int8-127
+- `exact-hybrid`: 0.909 ms -> 0.433 ms (-0.477 ms), cache hit rate 0.846, file reads 12 -> 1, decode loads 12 -> 1.
+- `compressed-hybrid`: 0.877 ms -> 0.486 ms (-0.392 ms), cache hit rate 0.846, file reads 12 -> 1, decode loads 12 -> 1.
+- `compressed-reranked-hybrid`: 1.293 ms -> 0.661 ms (-0.631 ms), cache hit rate 0.895, file reads 18 -> 1, decode loads 18 -> 1.
+- With cache enabled, `compressed-reranked-hybrid` vs `exact-hybrid`: 0.661 ms vs 0.433 ms. `compressed-hybrid` stays at 0.486 ms.
+
+## Status
+- Scalar quantizers (`scalar-quantizer`, `normalized-scalar`) remain the only canonical benchmarked quantizers in this report.
+- `TurboQuantAdapter` is not geometrically fixed in this sprint. The code stays in the repo for experiments, but canonical scripts and summary tables exclude it.

--- a/reports/cache_sprint4_benchmark.md
+++ b/reports/cache_sprint4_benchmark.md
@@ -1,0 +1,28 @@
+# Cache Sprint 4 Benchmark
+
+| Fixture | Quantizer | Cache mode | Query path | Latency ms | Cache hit rate | File reads | Decode loads | Candidates | Rerank ms |
+|---|---|---|---|---:|---:|---:|---:|---:|---:|
+| tiny_fixture | scalar-int8-127 | cache-disabled | exact-hybrid | 0.909 | 0.000 | 12 | 12 | 2.0 | 0.000 |
+| tiny_fixture | scalar-int8-127 | cache-disabled | compressed-hybrid | 0.877 | 0.000 | 12 | 12 | 2.0 | 0.000 |
+| tiny_fixture | scalar-int8-127 | cache-disabled | compressed-reranked-hybrid | 1.293 | 0.000 | 18 | 18 | 8.0 | 0.431 |
+| tiny_fixture | scalar-int8-127 | cache-enabled | exact-hybrid | 0.433 | 0.846 | 1 | 1 | 2.0 | 0.000 |
+| tiny_fixture | scalar-int8-127 | cache-enabled | compressed-hybrid | 0.486 | 0.846 | 1 | 1 | 2.0 | 0.000 |
+| tiny_fixture | scalar-int8-127 | cache-enabled | compressed-reranked-hybrid | 0.661 | 0.895 | 1 | 1 | 8.0 | 0.196 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-disabled | exact-hybrid | 0.970 | 0.000 | 12 | 12 | 2.0 | 0.000 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-disabled | compressed-hybrid | 1.176 | 0.000 | 12 | 12 | 2.0 | 0.000 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-disabled | compressed-reranked-hybrid | 1.719 | 0.000 | 18 | 18 | 8.0 | 0.516 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-enabled | exact-hybrid | 0.428 | 0.846 | 1 | 1 | 2.0 | 0.000 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-enabled | compressed-hybrid | 0.562 | 0.846 | 1 | 1 | 2.0 | 0.000 |
+| tiny_fixture | normalized-scalar-int8-127 | cache-enabled | compressed-reranked-hybrid | 0.836 | 0.895 | 1 | 1 | 8.0 | 0.231 |
+| clustered_fixture_16 | scalar-int8-127 | cache-disabled | exact-hybrid | 2.865 | 0.000 | 16 | 16 | 5.0 | 0.000 |
+| clustered_fixture_16 | scalar-int8-127 | cache-disabled | compressed-hybrid | 3.025 | 0.000 | 16 | 16 | 5.0 | 0.000 |
+| clustered_fixture_16 | scalar-int8-127 | cache-disabled | compressed-reranked-hybrid | 4.228 | 0.000 | 24 | 24 | 20.0 | 1.305 |
+| clustered_fixture_16 | scalar-int8-127 | cache-enabled | exact-hybrid | 0.682 | 0.882 | 1 | 1 | 5.0 | 0.000 |
+| clustered_fixture_16 | scalar-int8-127 | cache-enabled | compressed-hybrid | 1.088 | 0.882 | 1 | 1 | 5.0 | 0.000 |
+| clustered_fixture_16 | scalar-int8-127 | cache-enabled | compressed-reranked-hybrid | 1.313 | 0.920 | 1 | 1 | 20.0 | 0.258 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-disabled | exact-hybrid | 3.157 | 0.000 | 16 | 16 | 5.0 | 0.000 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-disabled | compressed-hybrid | 4.689 | 0.000 | 16 | 16 | 5.0 | 0.000 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-disabled | compressed-reranked-hybrid | 5.894 | 0.000 | 24 | 24 | 20.0 | 1.585 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-enabled | exact-hybrid | 0.900 | 0.882 | 1 | 1 | 5.0 | 0.000 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-enabled | compressed-hybrid | 2.135 | 0.882 | 1 | 1 | 5.0 | 0.000 |
+| clustered_fixture_16 | normalized-scalar-int8-127 | cache-enabled | compressed-reranked-hybrid | 2.471 | 0.920 | 1 | 1 | 20.0 | 0.389 |

--- a/scripts/run_cache_sprint4_benchmark.py
+++ b/scripts/run_cache_sprint4_benchmark.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from recalllayer.benchmark.cache_sprint4 import (
+    build_cache_sprint4_rows,
+    render_cache_sprint4_markdown,
+    summarize_cache_sprint4,
+)
+
+
+def main() -> None:
+    rows = build_cache_sprint4_rows()
+    reports_dir = Path("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    benchmark_path = reports_dir / "cache_sprint4_benchmark.md"
+    summary_path = Path("docs") / "benchmark-cache-sprint-4.md"
+    benchmark_path.write_text(render_cache_sprint4_markdown(rows) + "\n", encoding="utf-8")
+    summary_path.write_text(summarize_cache_sprint4(rows), encoding="utf-8")
+    print(benchmark_path)
+    print(summary_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_canonical_flow.py
+++ b/scripts/run_canonical_flow.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import subprocess
 import sys
 
-
 COMMANDS = [
     [sys.executable, "scripts/run_showcase_benchmark.py"],
-    [sys.executable, "scripts/run_quantizer_comparison.py"],
-    [sys.executable, "scripts/run_extended_benchmark.py"],
-    [sys.executable, "scripts/export_all_reports.py"],
+    [sys.executable, "scripts/export_proof_pack.py"],
+    [sys.executable, "scripts/run_cache_sprint4_benchmark.py"],
 ]
 
 

--- a/src/recalllayer/benchmark/cache_sprint4.py
+++ b/src/recalllayer/benchmark/cache_sprint4.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from recalllayer.benchmark.cluster_fixtures import clustered_fixture
+from recalllayer.benchmark.fixtures import tiny_fixture
+from recalllayer.benchmark.mini_harness import HarnessPathResult, run_mini_harness
+from recalllayer.engine.showcase_scored_db import ShowcaseScoredDatabase
+from recalllayer.quantization.experiments import NormalizedScalarQuantizer
+from recalllayer.quantization.scalar import ScalarQuantizer
+
+
+@dataclass(slots=True)
+class CacheSprint4Row:
+    fixture_name: str
+    quantizer_name: str
+    cache_mode: str
+    query_path: str
+    latency_ms: float
+    cache_hit_rate: float
+    file_reads: int
+    decode_loads: int
+    candidate_generation_count: float
+    rerank_latency_ms: float
+
+
+def build_cache_sprint4_rows(root_prefix: str = ".cache_sprint4") -> list[CacheSprint4Row]:
+    rows: list[CacheSprint4Row] = []
+    fixtures = [
+        (tiny_fixture(), 2),
+        (clustered_fixture(size_per_cluster=16), 5),
+    ]
+    quantizers = [
+        ScalarQuantizer(),
+        NormalizedScalarQuantizer(),
+    ]
+    for fixture_index, (dataset, top_k) in enumerate(fixtures):
+        for quantizer_index, quantizer in enumerate(quantizers):
+            for cache_enabled, cache_mode in ((False, "cache-disabled"), (True, "cache-enabled")):
+                db = ShowcaseScoredDatabase(
+                    collection_id=f"{dataset.name}-{quantizer.name}-{cache_mode}",
+                    root_dir=f"{root_prefix}-{fixture_index}-{quantizer_index}-{cache_mode}",
+                    quantizer=quantizer,
+                    enable_segment_cache=cache_enabled,
+                )
+                for item in dataset.items:
+                    db.upsert(
+                        vector_id=item.vector_id, embedding=item.embedding, metadata=item.metadata
+                    )
+                db.flush_mutable(segment_id="seg-1", generation=1)
+                result = run_mini_harness(db, dataset.queries, top_k=top_k)
+                rows.extend(
+                    _rows_for_result(
+                        fixture_name=dataset.name,
+                        quantizer_name=quantizer.name,
+                        cache_mode=cache_mode,
+                        result=result,
+                    )
+                )
+    return rows
+
+
+def render_cache_sprint4_markdown(rows: list[CacheSprint4Row]) -> str:
+    lines = [
+        "# Cache Sprint 4 Benchmark",
+        "",
+        (
+            "| Fixture | Quantizer | Cache mode | Query path | Latency ms | Cache hit rate | "
+            "File reads | Decode loads | Candidates | Rerank ms |"
+        ),
+        "|---|---|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row.fixture_name} | {row.quantizer_name} | {row.cache_mode} | "
+            f"{row.query_path} | {row.latency_ms:.3f} | {row.cache_hit_rate:.3f} | "
+            f"{row.file_reads} | {row.decode_loads} | "
+            f"{row.candidate_generation_count:.1f} | {row.rerank_latency_ms:.3f} |"
+        )
+    return "\n".join(lines)
+
+
+def summarize_cache_sprint4(rows: list[CacheSprint4Row]) -> str:
+    indexed = {
+        (row.fixture_name, row.quantizer_name, row.query_path, row.cache_mode): row for row in rows
+    }
+    lines = [
+        "# Sprint 4 Cache Summary",
+        "",
+        (
+            "Representative subset: `tiny_fixture` and `clustered_fixture`, using the "
+            "canonical scalar quantizer plus `normalized-scalar` as a scalar control. "
+            "`TurboQuantAdapter` is intentionally excluded from the canonical table "
+            "and remains experimental only."
+        ),
+        "",
+    ]
+    for fixture_name, quantizer_name in sorted(
+        {(row.fixture_name, row.quantizer_name) for row in rows}
+    ):
+        lines.append(f"## {fixture_name} / {quantizer_name}")
+        for query_path in ("exact-hybrid", "compressed-hybrid", "compressed-reranked-hybrid"):
+            before = indexed.get((fixture_name, quantizer_name, query_path, "cache-disabled"))
+            after = indexed.get((fixture_name, quantizer_name, query_path, "cache-enabled"))
+            if before is None or after is None:
+                continue
+            delta_ms = after.latency_ms - before.latency_ms
+            lines.append(
+                f"- `{query_path}`: {before.latency_ms:.3f} ms -> {after.latency_ms:.3f} ms "
+                f"({delta_ms:+.3f} ms), cache hit rate {after.cache_hit_rate:.3f}, "
+                f"file reads {before.file_reads} -> {after.file_reads}, decode loads "
+                f"{before.decode_loads} -> {after.decode_loads}."
+            )
+        exact = indexed.get((fixture_name, quantizer_name, "exact-hybrid", "cache-enabled"))
+        reranked = indexed.get(
+            (fixture_name, quantizer_name, "compressed-reranked-hybrid", "cache-enabled")
+        )
+        compressed = indexed.get(
+            (fixture_name, quantizer_name, "compressed-hybrid", "cache-enabled")
+        )
+        if exact is not None and compressed is not None and reranked is not None:
+            lines.append(
+                f"- With cache enabled, `compressed-reranked-hybrid` vs `exact-hybrid`: "
+                f"{reranked.latency_ms:.3f} ms vs {exact.latency_ms:.3f} ms. "
+                f"`compressed-hybrid` stays at {compressed.latency_ms:.3f} ms."
+            )
+        lines.append("")
+    lines.extend(
+        [
+            "## Status",
+            (
+                "- Scalar quantizers (`scalar-quantizer`, `normalized-scalar`) remain "
+                "the only canonical benchmarked quantizers in this report."
+            ),
+            (
+                "- `TurboQuantAdapter` is not geometrically fixed in this sprint. "
+                "The code stays in the repo for experiments, but canonical scripts "
+                "and summary tables exclude it."
+            ),
+        ]
+    )
+    return "\n".join(lines).strip() + "\n"
+
+
+def _rows_for_result(
+    *,
+    fixture_name: str,
+    quantizer_name: str,
+    cache_mode: str,
+    result: object,
+) -> list[CacheSprint4Row]:
+    rows = [
+        _row(fixture_name, quantizer_name, cache_mode, result.exact),
+        _row(fixture_name, quantizer_name, cache_mode, result.compressed),
+    ]
+    if result.reranked is not None:
+        rows.append(_row(fixture_name, quantizer_name, cache_mode, result.reranked))
+    return rows
+
+
+def _row(
+    fixture_name: str,
+    quantizer_name: str,
+    cache_mode: str,
+    result: HarnessPathResult,
+) -> CacheSprint4Row:
+    indexed_cache = result.cache_stats.get("indexed_cache", {})
+    decoded_cache = result.cache_stats.get("decoded_cache", {})
+    reads = result.cache_stats.get("segment_reads", {})
+    total_hits = float(indexed_cache.get("hits", 0)) + float(decoded_cache.get("hits", 0))
+    total_misses = float(indexed_cache.get("misses", 0)) + float(decoded_cache.get("misses", 0))
+    denominator = total_hits + total_misses
+    return CacheSprint4Row(
+        fixture_name=fixture_name,
+        quantizer_name=quantizer_name,
+        cache_mode=cache_mode,
+        query_path=result.path_name,
+        latency_ms=result.latency_ms,
+        cache_hit_rate=(total_hits / denominator) if denominator else 0.0,
+        file_reads=int(reads.get("file_reads", 0)),
+        decode_loads=int(reads.get("decode_loads", 0)),
+        candidate_generation_count=float(result.trace.get("candidate_generation_count", 0.0)),
+        rerank_latency_ms=float(result.trace.get("rerank_latency_ms", 0.0)),
+    )

--- a/src/recalllayer/benchmark/mini_harness.py
+++ b/src/recalllayer/benchmark/mini_harness.py
@@ -1,21 +1,99 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from time import perf_counter
+from typing import Any, Callable
 
-from recalllayer.benchmark.metrics import recall_at_k
+from recalllayer.benchmark.metrics import average_latency_ms, recall_at_k
 from recalllayer.engine.local_db import LocalVectorDatabase
 
 
 @dataclass(slots=True)
-class HarnessResult:
-    exact_elapsed_ms: float
-    compressed_elapsed_ms: float
+class HarnessPathResult:
+    path_name: str
+    latency_ms: float
     recall_at_1: float
     recall_at_10: float
+    trace: dict[str, Any] = field(default_factory=dict)
+    cache_stats: dict[str, Any] = field(default_factory=dict)
 
 
-def run_mini_harness(db: LocalVectorDatabase, queries: list[list[float]], *, top_k: int = 10) -> HarnessResult:
+@dataclass(slots=True)
+class HarnessResult:
+    exact: HarnessPathResult
+    compressed: HarnessPathResult
+    reranked: HarnessPathResult | None = None
+
+    @property
+    def exact_elapsed_ms(self) -> float:
+        return self.exact.latency_ms
+
+    @property
+    def compressed_elapsed_ms(self) -> float:
+        return self.compressed.latency_ms
+
+    @property
+    def recall_at_1(self) -> float:
+        return self.compressed.recall_at_1
+
+    @property
+    def recall_at_10(self) -> float:
+        return self.compressed.recall_at_10
+
+
+def run_mini_harness(
+    db: LocalVectorDatabase, queries: list[list[float]], *, top_k: int = 10
+) -> HarnessResult:
+    if hasattr(db, "query_exact_hybrid_hits") and hasattr(db, "query_compressed_hybrid_hits"):
+        exact_ids, exact_trace, exact_cache, exact_latency_ms = _run_path(
+            db,
+            queries,
+            query_fn=lambda query: db.query_exact_hybrid_hits(query, top_k=top_k),
+        )
+        compressed_ids, compressed_trace, compressed_cache, compressed_latency_ms = _run_path(
+            db,
+            queries,
+            query_fn=lambda query: db.query_compressed_hybrid_hits(query, top_k=top_k),
+        )
+        reranked: HarnessPathResult | None = None
+        if hasattr(db, "query_compressed_reranked_hybrid_hits"):
+            reranked_ids, reranked_trace, reranked_cache, reranked_latency_ms = _run_path(
+                db,
+                queries,
+                query_fn=lambda query: db.query_compressed_reranked_hybrid_hits(query, top_k=top_k),
+            )
+            reranked = HarnessPathResult(
+                path_name="compressed-reranked-hybrid",
+                latency_ms=reranked_latency_ms,
+                recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=reranked_ids, k=1),
+                recall_at_10=recall_at_k(
+                    expected_ids=exact_ids, actual_ids=reranked_ids, k=min(10, top_k)
+                ),
+                trace=reranked_trace,
+                cache_stats=reranked_cache,
+            )
+        return HarnessResult(
+            exact=HarnessPathResult(
+                path_name="exact-hybrid",
+                latency_ms=exact_latency_ms,
+                recall_at_1=1.0,
+                recall_at_10=1.0,
+                trace=exact_trace,
+                cache_stats=exact_cache,
+            ),
+            compressed=HarnessPathResult(
+                path_name="compressed-hybrid",
+                latency_ms=compressed_latency_ms,
+                recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=1),
+                recall_at_10=recall_at_k(
+                    expected_ids=exact_ids, actual_ids=compressed_ids, k=min(10, top_k)
+                ),
+                trace=compressed_trace,
+                cache_stats=compressed_cache,
+            ),
+            reranked=reranked,
+        )
+
     exact_ids: list[str] = []
     compressed_ids: list[str] = []
 
@@ -30,8 +108,60 @@ def run_mini_harness(db: LocalVectorDatabase, queries: list[list[float]], *, top
     compressed_elapsed_ms = (perf_counter() - start) * 1000.0
 
     return HarnessResult(
-        exact_elapsed_ms=exact_elapsed_ms,
-        compressed_elapsed_ms=compressed_elapsed_ms,
-        recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=1),
-        recall_at_10=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=min(10, top_k)),
+        exact=HarnessPathResult(
+            path_name="exact",
+            latency_ms=exact_elapsed_ms,
+            recall_at_1=1.0,
+            recall_at_10=1.0,
+        ),
+        compressed=HarnessPathResult(
+            path_name="compressed",
+            latency_ms=compressed_elapsed_ms,
+            recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=1),
+            recall_at_10=recall_at_k(
+                expected_ids=exact_ids, actual_ids=compressed_ids, k=min(10, top_k)
+            ),
+        ),
     )
+
+
+def _run_path(
+    db: LocalVectorDatabase,
+    queries: list[list[float]],
+    *,
+    query_fn: Callable[[list[float]], list[object]],
+) -> tuple[list[str], dict[str, Any], dict[str, Any], float]:
+    if hasattr(db, "clear_segment_caches"):
+        db.clear_segment_caches()
+    if hasattr(db, "reset_segment_cache_stats"):
+        db.reset_segment_cache_stats()
+    ids: list[str] = []
+    samples_ms: list[float] = []
+    trace_totals: dict[str, float] = {
+        "candidate_generation_count": 0.0,
+        "mutable_candidate_count": 0.0,
+        "sealed_candidate_count": 0.0,
+        "result_count": 0.0,
+        "rerank_candidate_count": 0.0,
+        "mutable_search_latency_ms": 0.0,
+        "sealed_search_latency_ms": 0.0,
+        "merge_latency_ms": 0.0,
+        "rerank_latency_ms": 0.0,
+        "materialization_latency_ms": 0.0,
+    }
+    trace_mode = ""
+    for query in queries:
+        start = perf_counter()
+        hits = query_fn(query)
+        samples_ms.append((perf_counter() - start) * 1000.0)
+        ids.extend(hit.vector_id if hasattr(hit, "vector_id") else hit for hit in hits)
+        if hasattr(db, "last_query_trace"):
+            trace = db.last_query_trace()
+            trace_mode = str(trace.get("mode", trace_mode))
+            for key in trace_totals:
+                trace_totals[key] += float(trace.get(key) or 0.0)
+    divisor = max(1, len(queries))
+    averaged_trace = {key: value / divisor for key, value in trace_totals.items()}
+    averaged_trace["mode"] = trace_mode
+    cache_stats = db.segment_cache_stats() if hasattr(db, "segment_cache_stats") else {}
+    return ids, averaged_trace, cache_stats, average_latency_ms(samples_ms)

--- a/src/recalllayer/benchmark/proof_pack.py
+++ b/src/recalllayer/benchmark/proof_pack.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from time import perf_counter
-from typing import Callable
 
 from recalllayer.benchmark.cluster_fixtures import clustered_fixture
 from recalllayer.benchmark.fixtures import tiny_fixture
-from recalllayer.benchmark.metrics import average_latency_ms, recall_at_k
+from recalllayer.benchmark.mini_harness import HarnessPathResult, run_mini_harness
 from recalllayer.engine.showcase_scored_db import ShowcaseScoredDatabase
 from recalllayer.quantization.scalar import ScalarQuantizer
-from recalllayer.quantization.turboquant_adapter import TurboQuantAdapter
 
 
 @dataclass(slots=True)
@@ -20,17 +17,29 @@ class ProofRow:
     latency_ms: float
     recall_at_1: float
     recall_at_10: float
+    cache_hit_rate: float
+    file_reads: int
+    decode_loads: int
+    candidate_generation_count: float
+    rerank_latency_ms: float
     note: str
 
 
 def render_proof_markdown(rows: list[ProofRow]) -> str:
     lines = [
-        "| Fixture | Query path | Backend | Latency ms | Recall@1 | Recall@10 | Note |",
-        "|---|---|---|---:|---:|---:|---|",
+        (
+            "| Fixture | Query path | Backend | Latency ms | Recall@1 | Recall@10 | "
+            "Cache hit rate | File reads | Decode loads | Candidates | Rerank ms | Note |"
+        ),
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
     ]
     for row in rows:
         lines.append(
-            f"| {row.fixture_name} | {row.query_path} | {row.backend} | {row.latency_ms:.3f} | {row.recall_at_1:.3f} | {row.recall_at_10:.3f} | {row.note} |"
+            f"| {row.fixture_name} | {row.query_path} | {row.backend} | "
+            f"{row.latency_ms:.3f} | {row.recall_at_1:.3f} | {row.recall_at_10:.3f} | "
+            f"{row.cache_hit_rate:.3f} | {row.file_reads} | {row.decode_loads} | "
+            f"{row.candidate_generation_count:.1f} | {row.rerank_latency_ms:.3f} | "
+            f"{row.note} |"
         )
     return "\n".join(lines)
 
@@ -43,99 +52,62 @@ def build_proof_rows(root_prefix: str = ".proof_pack") -> list[ProofRow]:
 
     rows: list[ProofRow] = []
     for fixture_index, (dataset, top_k) in enumerate(fixture_specs):
-        exact_db = ShowcaseScoredDatabase(
-            collection_id=f"{dataset.name}-exact-{fixture_index}",
-            root_dir=f"{root_prefix}-exact-{fixture_index}",
+        db = ShowcaseScoredDatabase(
+            collection_id=f"{dataset.name}-scalar-{fixture_index}",
+            root_dir=f"{root_prefix}-{fixture_index}",
             quantizer=ScalarQuantizer(),
         )
         for item in dataset.items:
-            exact_db.upsert(vector_id=item.vector_id, embedding=item.embedding, metadata=item.metadata)
-        exact_db.flush_mutable(segment_id="seg-1", generation=1)
+            db.upsert(vector_id=item.vector_id, embedding=item.embedding, metadata=item.metadata)
+        db.flush_mutable(segment_id="seg-1", generation=1)
 
-        exact_ids, exact_latency_ms = _run_path(
-            exact_db,
-            dataset.queries,
-            top_k=top_k,
-            query_fn=lambda query: exact_db.query_exact_hybrid_hits(query, top_k=top_k),
+        result = run_mini_harness(db, dataset.queries, top_k=top_k)
+        rows.append(
+            _row_from_result(
+                dataset.name, "scalar-quantizer", result.exact, "Reference exact hybrid path."
+            )
         )
         rows.append(
-            ProofRow(
-                fixture_name=dataset.name,
-                query_path="exact-hybrid",
-                backend="exact-baseline",
-                latency_ms=exact_latency_ms,
-                recall_at_1=1.0,
-                recall_at_10=1.0,
-                note="Reference path for recall comparison.",
+            _row_from_result(
+                dataset.name,
+                "scalar-quantizer",
+                result.compressed,
+                "Canonical compressed hybrid path.",
             )
         )
-
-        backend_specs = [
-            (ScalarQuantizer(), "scalar-quantizer", "Measured compressed scan baseline."),
-            (TurboQuantAdapter(), "turboquant-adapter", "Adapter-based placeholder, not full-fidelity TurboQuant."),
-        ]
-
-        for backend_index, (quantizer, backend_name, backend_note) in enumerate(backend_specs):
-            db = ShowcaseScoredDatabase(
-                collection_id=f"{dataset.name}-{backend_name}-{backend_index}",
-                root_dir=f"{root_prefix}-{fixture_index}-{backend_index}",
-                quantizer=quantizer,
-            )
-            for item in dataset.items:
-                db.upsert(vector_id=item.vector_id, embedding=item.embedding, metadata=item.metadata)
-            db.flush_mutable(segment_id="seg-1", generation=1)
-
-            compressed_ids, compressed_latency_ms = _run_path(
-                db,
-                dataset.queries,
-                top_k=top_k,
-                query_fn=lambda query: db.query_compressed_hybrid_hits(query, top_k=top_k),
-            )
+        if result.reranked is not None:
             rows.append(
-                ProofRow(
-                    fixture_name=dataset.name,
-                    query_path="compressed-hybrid",
-                    backend=backend_name,
-                    latency_ms=compressed_latency_ms,
-                    recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=1),
-                    recall_at_10=recall_at_k(expected_ids=exact_ids, actual_ids=compressed_ids, k=min(10, top_k)),
-                    note=backend_note,
-                )
-            )
-
-            reranked_ids, reranked_latency_ms = _run_path(
-                db,
-                dataset.queries,
-                top_k=top_k,
-                query_fn=lambda query: db.query_compressed_reranked_hybrid_hits(query, top_k=top_k),
-            )
-            rows.append(
-                ProofRow(
-                    fixture_name=dataset.name,
-                    query_path="compressed-reranked-hybrid",
-                    backend=backend_name,
-                    latency_ms=reranked_latency_ms,
-                    recall_at_1=recall_at_k(expected_ids=exact_ids, actual_ids=reranked_ids, k=1),
-                    recall_at_10=recall_at_k(expected_ids=exact_ids, actual_ids=reranked_ids, k=min(10, top_k)),
-                    note=f"{backend_note} Includes rerank over compressed candidates.",
+                _row_from_result(
+                    dataset.name,
+                    "scalar-quantizer",
+                    result.reranked,
+                    "Canonical compressed+rereank path over cached sealed payloads.",
                 )
             )
 
     return rows
 
 
-def _run_path(
-    db: ShowcaseScoredDatabase,
-    queries: list[list[float]],
-    *,
-    top_k: int,
-    query_fn: Callable[[list[float]], list[object]],
-) -> tuple[list[str], float]:
-    ids: list[str] = []
-    samples_ms: list[float] = []
-    for query in queries:
-        start = perf_counter()
-        hits = query_fn(query)
-        samples_ms.append((perf_counter() - start) * 1000.0)
-        ids.extend(hit.vector_id for hit in hits[:top_k])
-    return ids, average_latency_ms(samples_ms)
+def _row_from_result(
+    fixture_name: str, backend: str, result: HarnessPathResult, note: str
+) -> ProofRow:
+    indexed_cache = result.cache_stats.get("indexed_cache", {})
+    decoded_cache = result.cache_stats.get("decoded_cache", {})
+    reads = result.cache_stats.get("segment_reads", {})
+    total_hits = float(indexed_cache.get("hits", 0)) + float(decoded_cache.get("hits", 0))
+    total_misses = float(indexed_cache.get("misses", 0)) + float(decoded_cache.get("misses", 0))
+    denominator = total_hits + total_misses
+    return ProofRow(
+        fixture_name=fixture_name,
+        query_path=result.path_name,
+        backend=backend,
+        latency_ms=result.latency_ms,
+        recall_at_1=result.recall_at_1,
+        recall_at_10=result.recall_at_10,
+        cache_hit_rate=(total_hits / denominator) if denominator else 0.0,
+        file_reads=int(reads.get("file_reads", 0)),
+        decode_loads=int(reads.get("decode_loads", 0)),
+        candidate_generation_count=float(result.trace.get("candidate_generation_count", 0.0)),
+        rerank_latency_ms=float(result.trace.get("rerank_latency_ms", 0.0)),
+        note=note,
+    )

--- a/src/recalllayer/benchmark/showcase_runner.py
+++ b/src/recalllayer/benchmark/showcase_runner.py
@@ -23,10 +23,25 @@ def run_showcase_benchmark(root_dir: str = ".showcase_benchmark_db") -> Showcase
     result = run_mini_harness(db, dataset.queries, top_k=2)
     rows = [
         ComparisonRow(
-            name="showcase-scored-db",
-            latency_ms=result.compressed_elapsed_ms,
-            recall_at_1=result.recall_at_1,
-            recall_at_10=result.recall_at_10,
-        )
+            name=f"showcase-scored-db:{result.exact.path_name}",
+            latency_ms=result.exact.latency_ms,
+            recall_at_1=result.exact.recall_at_1,
+            recall_at_10=result.exact.recall_at_10,
+        ),
+        ComparisonRow(
+            name=f"showcase-scored-db:{result.compressed.path_name}",
+            latency_ms=result.compressed.latency_ms,
+            recall_at_1=result.compressed.recall_at_1,
+            recall_at_10=result.compressed.recall_at_10,
+        ),
     ]
+    if result.reranked is not None:
+        rows.append(
+            ComparisonRow(
+                name=f"showcase-scored-db:{result.reranked.path_name}",
+                latency_ms=result.reranked.latency_ms,
+                recall_at_1=result.reranked.recall_at_1,
+                recall_at_10=result.reranked.recall_at_10,
+            )
+        )
     return ShowcaseRunArtifacts(rows=rows)

--- a/src/recalllayer/engine/local_db.py
+++ b/src/recalllayer/engine/local_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -8,8 +9,12 @@ from recalllayer.engine.manifest_validation import raise_for_manifest_issues, va
 from recalllayer.engine.mutable_buffer import MutableBuffer
 from recalllayer.engine.query_executor import QueryExecutor
 from recalllayer.engine.recovery_manager import RecoveryManager
-from recalllayer.engine.sealed_segments import LocalSegmentStore, SegmentBuilder
-from recalllayer.engine.segment_gc_executor import SegmentGarbageCollectionExecution, SegmentGarbageCollectionExecutor
+from recalllayer.engine.sealed_segments import LocalSegmentStore, SegmentBuilder, SegmentReadStats
+from recalllayer.engine.segment_cache import SegmentReadCache
+from recalllayer.engine.segment_gc_executor import (
+    SegmentGarbageCollectionExecution,
+    SegmentGarbageCollectionExecutor,
+)
 from recalllayer.engine.segment_manifest_store import SegmentManifestStore
 from recalllayer.engine.write_log import DurabilityMode, WriteLog
 from recalllayer.model.manifest import SegmentState, ShardManifest
@@ -30,6 +35,8 @@ class LocalVectorDatabase:
         quantizer: Quantizer | None = None,
         flush_threshold: int | None = None,
         durability_mode: DurabilityMode = DurabilityMode.MEMORY,
+        segment_cache_size: int = 8,
+        enable_segment_cache: bool = True,
     ) -> None:
         self.collection_id = collection_id
         self.root_dir = Path(root_dir)
@@ -37,16 +44,26 @@ class LocalVectorDatabase:
         self.embedding_version = embedding_version
         self.quantizer_version = quantizer_version
         self.quantizer = quantizer or ScalarQuantizer()
+        self.enable_segment_cache = enable_segment_cache
 
         self.mutable_buffer = MutableBuffer(collection_id=collection_id)
-        self.write_log = WriteLog(self.root_dir / collection_id / "write_log.jsonl", durability_mode=durability_mode)
+        self.write_log = WriteLog(
+            self.root_dir / collection_id / "write_log.jsonl", durability_mode=durability_mode
+        )
         self.durability_mode = durability_mode
         self.manifest_store = ManifestStore(self.root_dir / "manifests")
         self.segment_manifest_store = SegmentManifestStore(self.root_dir / "segment-manifests")
         self.segment_store = LocalSegmentStore(self.root_dir / "segments")
         self.segment_builder = SegmentBuilder(self.root_dir / "segments", quantizer=self.quantizer)
-        self.recovery_manager = RecoveryManager(write_log=self.write_log, mutable_buffer=self.mutable_buffer)
-        self.query_executor = QueryExecutor(mutable_buffer=self.mutable_buffer, quantizer=self.quantizer)
+        self.recovery_manager = RecoveryManager(
+            write_log=self.write_log, mutable_buffer=self.mutable_buffer
+        )
+        self.query_executor = QueryExecutor(
+            mutable_buffer=self.mutable_buffer, quantizer=self.quantizer
+        )
+        self.segment_cache = SegmentReadCache(segment_cache_size)
+        self.decoded_segment_cache = SegmentReadCache(segment_cache_size)
+        self.segment_read_stats = SegmentReadStats()
         self.flush_threshold = flush_threshold
 
         # Multi-shard support: per-shard mutable buffers and query executors.
@@ -58,7 +75,14 @@ class LocalVectorDatabase:
         self._write_epoch = self.mutable_buffer.watermark()
         self._auto_flush_segment_counter = 0
 
-    def upsert(self, *, vector_id: str, embedding: list[float], metadata: dict[str, object] | None = None, shard_id: str = "shard-0") -> int:  # noqa: E501
+    def upsert(
+        self,
+        *,
+        vector_id: str,
+        embedding: list[float],
+        metadata: dict[str, object] | None = None,
+        shard_id: str = "shard-0",
+    ) -> int:  # noqa: E501
         self._write_epoch += 1
         self.write_log.append_upsert(
             collection_id=self.collection_id,
@@ -97,7 +121,9 @@ class LocalVectorDatabase:
         if shard_id not in self._shard_buffers:
             buf = MutableBuffer(collection_id=self.collection_id)
             self._shard_buffers[shard_id] = buf
-            self._shard_query_executors[shard_id] = QueryExecutor(mutable_buffer=buf, quantizer=self.quantizer)
+            self._shard_query_executors[shard_id] = QueryExecutor(
+                mutable_buffer=buf, quantizer=self.quantizer
+            )
             self._shard_auto_flush_counters[shard_id] = 0
         return self._shard_buffers[shard_id]
 
@@ -111,7 +137,9 @@ class LocalVectorDatabase:
         buf = self._get_mutable_buffer(shard_id)
         mutable_count = len(buf.all_entries())
         if mutable_count >= self.flush_threshold:
-            self._shard_auto_flush_counters[shard_id] = self._shard_auto_flush_counters.get(shard_id, 0) + 1
+            self._shard_auto_flush_counters[shard_id] = (
+                self._shard_auto_flush_counters.get(shard_id, 0) + 1
+            )
             counter = self._shard_auto_flush_counters[shard_id]
             self._auto_flush_segment_counter = counter  # keep compat attr in sync for shard-0
             self.flush_mutable(
@@ -128,7 +156,9 @@ class LocalVectorDatabase:
         segment_manifests = self.segment_manifest_store.list_manifests(
             collection_id=self.collection_id, shard_id=shard_id
         )
-        shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
+        shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
         if shard_manifest is None:
             return None
         active_ids = set(shard_manifest.active_segment_ids)
@@ -151,13 +181,32 @@ class LocalVectorDatabase:
             return None
         return 1.0 - fraction
 
-    def query_exact(self, query_vector: list[float], *, top_k: int, shard_id: str = "shard-0") -> list[str]:
-        return [item.vector_id for item in self._get_query_executor(shard_id).search_exact(query_vector, top_k=top_k)]
+    def query_exact(
+        self, query_vector: list[float], *, top_k: int, shard_id: str = "shard-0"
+    ) -> list[str]:
+        return [
+            item.vector_id
+            for item in self._get_query_executor(shard_id).search_exact(query_vector, top_k=top_k)
+        ]
 
-    def query_compressed(self, query_vector: list[float], *, top_k: int, shard_id: str = "shard-0") -> list[str]:
-        return [item.vector_id for item in self._get_query_executor(shard_id).search_compressed(query_vector, top_k=top_k)]
+    def query_compressed(
+        self, query_vector: list[float], *, top_k: int, shard_id: str = "shard-0"
+    ) -> list[str]:
+        return [
+            item.vector_id
+            for item in self._get_query_executor(shard_id).search_compressed(
+                query_vector, top_k=top_k
+            )
+        ]
 
-    def flush_mutable(self, *, shard_id: str = "shard-0", segment_id: str = "seg-0", generation: int = 1, truncate_write_log: bool = False) -> ShardManifest | None:  # noqa: E501
+    def flush_mutable(
+        self,
+        *,
+        shard_id: str = "shard-0",
+        segment_id: str = "seg-0",
+        generation: int = 1,
+        truncate_write_log: bool = False,
+    ) -> ShardManifest | None:  # noqa: E501
         buf = self._get_mutable_buffer(shard_id)
         entries = buf.all_entries()
         if not entries:
@@ -172,14 +221,22 @@ class LocalVectorDatabase:
             quantizer_version=self.quantizer_version,
             entries=entries,
         )
+        self.segment_cache.invalidate(_paths.segment_path)
+        self.decoded_segment_cache.invalidate(_paths.segment_path)
         now = datetime.now(timezone.utc)
         segment_manifest.state = SegmentState.ACTIVE
         segment_manifest.sealed_at = segment_manifest.sealed_at or now
         segment_manifest.activated_at = segment_manifest.activated_at or now
         self.segment_manifest_store.save(segment_manifest)
 
-        previous_shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
-        prior_active_segment_ids = previous_shard_manifest.active_segment_ids if previous_shard_manifest is not None else []
+        previous_shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
+        prior_active_segment_ids = (
+            previous_shard_manifest.active_segment_ids
+            if previous_shard_manifest is not None
+            else []
+        )
         shard_manifest = ShardManifest(
             shard_id=shard_id,
             collection_id=self.collection_id,
@@ -202,14 +259,22 @@ class LocalVectorDatabase:
         return shard_manifest
 
     def load_manifest_set(self, *, shard_id: str = "shard-0") -> tuple[ShardManifest | None, list]:
-        shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
-        segment_manifests = self.segment_manifest_store.list_manifests(collection_id=self.collection_id, shard_id=shard_id)
+        shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
+        segment_manifests = self.segment_manifest_store.list_manifests(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
         if shard_manifest is not None:
-            issues = validate_manifest_set(shard_manifest=shard_manifest, segment_manifests=segment_manifests)
+            issues = validate_manifest_set(
+                shard_manifest=shard_manifest, segment_manifests=segment_manifests
+            )
             raise_for_manifest_issues(issues)
         return shard_manifest, segment_manifests
 
-    def collect_retired_segments(self, *, shard_id: str = "shard-0") -> SegmentGarbageCollectionExecution:
+    def collect_retired_segments(
+        self, *, shard_id: str = "shard-0"
+    ) -> SegmentGarbageCollectionExecution:
         executor = SegmentGarbageCollectionExecutor(
             segment_manifest_store=self.segment_manifest_store,
             segments_root=self.root_dir / "segments",
@@ -218,14 +283,20 @@ class LocalVectorDatabase:
         return executor.collect_shard(collection_id=self.collection_id, shard_id=shard_id)
 
     def recover(self, *, shard_id: str = "shard-0") -> int:
-        shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
-        replay_from_write_epoch = shard_manifest.replay_from_write_epoch if shard_manifest is not None else 0
+        shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
+        replay_from_write_epoch = (
+            shard_manifest.replay_from_write_epoch if shard_manifest is not None else 0
+        )
         applied = self.recovery_manager.replay(
             embedding_version=self.embedding_version,
             quantizer_version=self.quantizer_version,
             after_write_epoch=replay_from_write_epoch,
         )
-        self._write_epoch = max(self._write_epoch, self.mutable_buffer.watermark(), replay_from_write_epoch)
+        self._write_epoch = max(
+            self._write_epoch, self.mutable_buffer.watermark(), replay_from_write_epoch
+        )
         return applied
 
     # ------------------------------------------------------------------
@@ -263,7 +334,9 @@ class LocalVectorDatabase:
         total_rows_all = 0
 
         for shard_id in known_shards:
-            shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
+            shard_manifest = self.manifest_store.load(
+                collection_id=self.collection_id, shard_id=shard_id
+            )
             if shard_manifest is None:
                 continue
             active_ids = set(shard_manifest.active_segment_ids)
@@ -297,3 +370,19 @@ class LocalVectorDatabase:
             "mutable_buffer_size": mutable_buffer_size,
             "storage_bytes": storage_bytes,
         }
+
+    def segment_cache_stats(self) -> dict[str, object]:
+        return {
+            "indexed_cache": asdict(self.segment_cache.stats()),
+            "decoded_cache": asdict(self.decoded_segment_cache.stats()),
+            "segment_reads": self.segment_read_stats.snapshot(),
+        }
+
+    def reset_segment_cache_stats(self) -> None:
+        self.segment_cache.reset_stats()
+        self.decoded_segment_cache.reset_stats()
+        self.segment_read_stats.reset()
+
+    def clear_segment_caches(self) -> None:
+        self.segment_cache.clear()
+        self.decoded_segment_cache.clear()

--- a/src/recalllayer/engine/sealed_segments.py
+++ b/src/recalllayer/engine/sealed_segments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from time import perf_counter
 from typing import Iterable, Iterator
 
 import numpy as np
@@ -20,6 +21,34 @@ KNOWN_SEGMENT_FORMAT_VERSIONS = {"v1"}
 class LocalSegmentPaths:
     segment_path: Path
     manifest_path: Path
+
+
+@dataclass(slots=True)
+class SegmentReadStats:
+    file_reads: int = 0
+    file_read_bytes: int = 0
+    file_read_latency_ms: float = 0.0
+    decode_loads: int = 0
+    decoded_vector_count: int = 0
+    decode_latency_ms: float = 0.0
+
+    def snapshot(self) -> dict[str, float | int]:
+        return {
+            "file_reads": self.file_reads,
+            "file_read_bytes": self.file_read_bytes,
+            "file_read_latency_ms": self.file_read_latency_ms,
+            "decode_loads": self.decode_loads,
+            "decoded_vector_count": self.decoded_vector_count,
+            "decode_latency_ms": self.decode_latency_ms,
+        }
+
+    def reset(self) -> None:
+        self.file_reads = 0
+        self.file_read_bytes = 0
+        self.file_read_latency_ms = 0.0
+        self.decode_loads = 0
+        self.decoded_vector_count = 0
+        self.decode_latency_ms = 0.0
 
 
 class SegmentBuilder:
@@ -52,7 +81,10 @@ class SegmentBuilder:
 
         with segment_path.open("w", encoding="utf-8") as handle:
             # Write a header row with format version
-            header: dict[str, object] = {"__header__": True, "format_version": SEGMENT_FORMAT_VERSION}
+            header: dict[str, object] = {
+                "__header__": True,
+                "format_version": SEGMENT_FORMAT_VERSION,
+            }
             handle.write(json.dumps(header, separators=(",", ":")))
             handle.write("\n")
             for local_docno, entry in enumerate(entries):
@@ -67,8 +99,12 @@ class SegmentBuilder:
                     }
                     handle.write(json.dumps(payload, separators=(",", ":")))
                     handle.write("\n")
-                    min_write_epoch = epoch if min_write_epoch is None else min(min_write_epoch, epoch)
-                    max_write_epoch = epoch if max_write_epoch is None else max(max_write_epoch, epoch)
+                    min_write_epoch = (
+                        epoch if min_write_epoch is None else min(min_write_epoch, epoch)
+                    )
+                    max_write_epoch = (
+                        epoch if max_write_epoch is None else max(max_write_epoch, epoch)
+                    )
                     continue
                 if entry.embedding is None:
                     continue
@@ -108,9 +144,12 @@ class SegmentBuilder:
 class SegmentReader:
     """Reads local JSONL-backed sealed segments."""
 
-    def __init__(self, segment_path: str | Path, *, cache=None) -> None:
+    def __init__(
+        self, segment_path: str | Path, *, cache=None, read_stats: SegmentReadStats | None = None
+    ) -> None:
         self.segment_path = Path(segment_path)
         self._cache = cache  # optional SegmentReadCache instance
+        self._read_stats = read_stats
 
     def read_format_version(self) -> str | None:
         """Return the format_version from the segment header, or None if absent."""
@@ -135,32 +174,47 @@ class SegmentReader:
         yield from vectors
 
     def _read_indexed_vectors(self) -> Iterator[IndexedVector]:
+        read_start = perf_counter()
         with self.segment_path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                payload = json.loads(line)
-                # First line may be a header; validate version and skip it.
-                if payload.get("__header__"):
-                    version = payload.get("format_version")
-                    if version not in KNOWN_SEGMENT_FORMAT_VERSIONS:
-                        raise ValueError(
-                            f"Unknown segment format version {version!r} in {self.segment_path}. "
-                            f"Known versions: {sorted(KNOWN_SEGMENT_FORMAT_VERSIONS)}"
-                        )
-                    continue
-                # Skip tombstone rows
-                if payload.get("is_deleted"):
-                    continue
-                yield IndexedVector(
-                    vector_id=payload["vector_id"],
-                    encoded=EncodedVector(
-                        codes=np.asarray(payload["codes"], dtype=np.int8),
-                        scale=float(payload["scale"]),
-                    ),
-                    metadata=payload.get("metadata", {}),
-                )
+            lines = handle.readlines()
+        read_latency_ms = (perf_counter() - read_start) * 1000.0
+        if self._read_stats is not None:
+            self._read_stats.file_reads += 1
+            self._read_stats.file_read_bytes += self.segment_path.stat().st_size
+            self._read_stats.file_read_latency_ms += read_latency_ms
+
+        decode_start = perf_counter()
+        decoded_count = 0
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            # First line may be a header; validate version and skip it.
+            if payload.get("__header__"):
+                version = payload.get("format_version")
+                if version not in KNOWN_SEGMENT_FORMAT_VERSIONS:
+                    raise ValueError(
+                        f"Unknown segment format version {version!r} in {self.segment_path}. "
+                        f"Known versions: {sorted(KNOWN_SEGMENT_FORMAT_VERSIONS)}"
+                    )
+                continue
+            # Skip tombstone rows
+            if payload.get("is_deleted"):
+                continue
+            decoded_count += 1
+            yield IndexedVector(
+                vector_id=payload["vector_id"],
+                encoded=EncodedVector(
+                    codes=np.asarray(payload["codes"], dtype=np.int8),
+                    scale=float(payload["scale"]),
+                ),
+                metadata=payload.get("metadata", {}),
+            )
+        if self._read_stats is not None:
+            self._read_stats.decode_loads += 1
+            self._read_stats.decoded_vector_count += decoded_count
+            self._read_stats.decode_latency_ms += (perf_counter() - decode_start) * 1000.0
 
 
 class LocalSegmentStore:

--- a/src/recalllayer/engine/segment_cache.py
+++ b/src/recalllayer/engine/segment_cache.py
@@ -1,14 +1,29 @@
-"""LRU segment read cache: caches decoded segment contents by segment path."""
+"""LRU segment read cache with simple counters."""
+
 from __future__ import annotations
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from recalllayer.retrieval.base import IndexedVector
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
 
 
-class SegmentReadCache:
-    """Cache decoded segment contents (IndexedVector list) by segment path.
+@dataclass(slots=True)
+class SegmentCacheStats:
+    hits: int
+    misses: int
+    evictions: int
+    writes: int
+    invalidations: int
+    size: int
+    max_size: int
+
+
+class SegmentReadCache(Generic[T]):
+    """Cache payloads by segment path.
 
     Provides LRU eviction and manual invalidation.
 
@@ -18,10 +33,15 @@ class SegmentReadCache:
 
     def __init__(self, max_size: int = 8) -> None:
         self._max_size = max(1, max_size)
-        self._cache: OrderedDict[str, list[IndexedVector]] = OrderedDict()
+        self._cache: OrderedDict[str, T] = OrderedDict()
         self._lock = Lock()
+        self._hits = 0
+        self._misses = 0
+        self._evictions = 0
+        self._writes = 0
+        self._invalidations = 0
 
-    def get(self, path: Path | str) -> list[IndexedVector] | None:
+    def get(self, path: Path | str) -> T | None:
         """Return cached contents for *path*, or None if not cached.
 
         Moves the entry to most-recently-used position on hit.
@@ -29,21 +49,25 @@ class SegmentReadCache:
         key = str(path)
         with self._lock:
             if key not in self._cache:
+                self._misses += 1
                 return None
+            self._hits += 1
             self._cache.move_to_end(key)
             return self._cache[key]
 
-    def put(self, path: Path | str, vectors: list[IndexedVector]) -> None:
-        """Store *vectors* for *path*, evicting LRU entry if at capacity."""
+    def put(self, path: Path | str, value: T) -> None:
+        """Store *value* for *path*, evicting LRU entry if at capacity."""
         key = str(path)
         with self._lock:
+            self._writes += 1
             if key in self._cache:
                 self._cache.move_to_end(key)
-                self._cache[key] = vectors
+                self._cache[key] = value
             else:
-                self._cache[key] = vectors
+                self._cache[key] = value
                 if len(self._cache) > self._max_size:
                     self._cache.popitem(last=False)
+                    self._evictions += 1
 
     def invalidate(self, path: Path | str) -> bool:
         """Remove a specific path from the cache. Returns True if it was present."""
@@ -51,6 +75,7 @@ class SegmentReadCache:
         with self._lock:
             if key in self._cache:
                 del self._cache[key]
+                self._invalidations += 1
                 return True
             return False
 
@@ -60,12 +85,34 @@ class SegmentReadCache:
             to_remove = [k for k in self._cache if k.startswith(prefix)]
             for k in to_remove:
                 del self._cache[k]
+            self._invalidations += len(to_remove)
             return len(to_remove)
 
     def clear(self) -> None:
         """Remove all entries."""
         with self._lock:
+            self._invalidations += len(self._cache)
             self._cache.clear()
+
+    def reset_stats(self) -> None:
+        with self._lock:
+            self._hits = 0
+            self._misses = 0
+            self._evictions = 0
+            self._writes = 0
+            self._invalidations = 0
+
+    def stats(self) -> SegmentCacheStats:
+        with self._lock:
+            return SegmentCacheStats(
+                hits=self._hits,
+                misses=self._misses,
+                evictions=self._evictions,
+                writes=self._writes,
+                invalidations=self._invalidations,
+                size=len(self._cache),
+                max_size=self._max_size,
+            )
 
     @property
     def size(self) -> int:

--- a/src/recalllayer/engine/showcase_db.py
+++ b/src/recalllayer/engine/showcase_db.py
@@ -17,6 +17,13 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
     segment results and applies exact metadata filters.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._last_query_trace: dict[str, Any] = {}
+
+    def last_query_trace(self) -> dict[str, Any]:
+        return dict(self._last_query_trace)
+
     def _tombstoned_vector_ids(self) -> set[str]:
         return {
             vector_id
@@ -25,9 +32,16 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
         }
 
     def _segment_paths(self, *, shard_id: str = "shard-0") -> list[str]:
-        shard_manifest = self.manifest_store.load(collection_id=self.collection_id, shard_id=shard_id)
+        shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
         if shard_manifest is None or not shard_manifest.active_segment_ids:
-            return [str(path) for path in self.segment_store.list_segment_files(collection_id=self.collection_id, shard_id=shard_id)]
+            return [
+                str(path)
+                for path in self.segment_store.list_segment_files(
+                    collection_id=self.collection_id, shard_id=shard_id
+                )
+            ]
 
         shard_dir = Path(self.segment_store.root_dir) / self.collection_id / shard_id
         paths: list[str] = []
@@ -63,19 +77,19 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
         filter_fn = build_filter_fn(filters or {})
         tombstoned_ids = self._tombstoned_vector_ids()
         candidates: list[Candidate] = []
-        paths = snapshot_paths if snapshot_paths is not None else self._segment_paths(shard_id=shard_id)
+        paths = (
+            snapshot_paths if snapshot_paths is not None else self._segment_paths(shard_id=shard_id)
+        )
         for path in paths:
-            reader = SegmentReader(path)
-            for indexed in reader.iter_indexed_vectors():
-                if indexed.vector_id in tombstoned_ids:
+            for vector_id, reconstructed, metadata in self._decoded_segment_payloads([path]):
+                if vector_id in tombstoned_ids:
                     continue
-                if candidate_ids is not None and indexed.vector_id not in candidate_ids:
+                if candidate_ids is not None and vector_id not in candidate_ids:
                     continue
-                if not filter_fn(indexed.metadata):
+                if not filter_fn(metadata):
                     continue
-                reconstructed = indexed.encoded.codes.astype("float32") * indexed.encoded.scale
-                score = float(sum(a * b for a, b in zip(query_vector, reconstructed.tolist())))
-                candidates.append(Candidate(vector_id=indexed.vector_id, score=score, metadata=indexed.metadata))
+                score = float(sum(a * b for a, b in zip(query_vector, reconstructed, strict=True)))
+                candidates.append(Candidate(vector_id=vector_id, score=score, metadata=metadata))
         candidates.sort(key=lambda item: item.score, reverse=True)
         return candidates[:top_k]
 
@@ -95,9 +109,15 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
         filter_fn = build_filter_fn(filters or {})
         tombstoned_ids = self._tombstoned_vector_ids()
         candidates: list[Candidate] = []
-        paths = snapshot_paths if snapshot_paths is not None else self._segment_paths(shard_id=shard_id)
+        paths = (
+            snapshot_paths if snapshot_paths is not None else self._segment_paths(shard_id=shard_id)
+        )
         for path in paths:
-            reader = SegmentReader(path)
+            reader = SegmentReader(
+                path,
+                cache=self.segment_cache if self.enable_segment_cache else None,
+                read_stats=self.segment_read_stats,
+            )
             for indexed in reader.iter_indexed_vectors():
                 if indexed.vector_id in tombstoned_ids:
                     continue
@@ -105,10 +125,63 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
                     continue
                 if not filter_fn(indexed.metadata):
                     continue
-                score = self.quantizer.approx_score(query_vector=query_vector, encoded=indexed.encoded)
-                candidates.append(Candidate(vector_id=indexed.vector_id, score=score, metadata=indexed.metadata))
+                score = self.quantizer.approx_score(
+                    query_vector=query_vector, encoded=indexed.encoded
+                )
+                candidates.append(
+                    Candidate(vector_id=indexed.vector_id, score=score, metadata=indexed.metadata)
+                )
         candidates.sort(key=lambda item: item.score, reverse=True)
         return candidates[:top_k]
+
+    def _decoded_segment_payloads(
+        self,
+        paths: list[str],
+    ) -> list[tuple[str, Any, dict[str, Any]]]:
+        payloads: list[tuple[str, Any, dict[str, Any]]] = []
+        for path in paths:
+            cached = self.decoded_segment_cache.get(path) if self.enable_segment_cache else None
+            if cached is not None:
+                payloads.extend(cached)
+                continue
+            reader = SegmentReader(
+                path,
+                cache=self.segment_cache if self.enable_segment_cache else None,
+                read_stats=self.segment_read_stats,
+            )
+            decoded_rows: list[tuple[str, Any, dict[str, Any]]] = []
+            for indexed in reader.iter_indexed_vectors():
+                decoded_rows.append(
+                    (
+                        indexed.vector_id,
+                        (indexed.encoded.codes.astype("float32") * indexed.encoded.scale).tolist(),
+                        indexed.metadata,
+                    )
+                )
+            if self.enable_segment_cache:
+                self.decoded_segment_cache.put(path, decoded_rows)
+            payloads.extend(decoded_rows)
+        return payloads
+
+    def _record_hybrid_trace(
+        self, *, mode: str, result: Any, top_k: int, filters: dict[str, Any] | None
+    ) -> None:
+        self._last_query_trace = {
+            "mode": mode,
+            "top_k": top_k,
+            "filters_applied": bool(filters),
+            "candidate_generation_count": len(result.mutable_candidates)
+            + len(result.sealed_candidates),
+            "mutable_candidate_count": len(result.mutable_candidates),
+            "sealed_candidate_count": len(result.sealed_candidates),
+            "result_count": len(result.ranked_hits),
+            "rerank_candidate_count": None,
+            "mutable_search_latency_ms": result.mutable_search_latency_ms,
+            "sealed_search_latency_ms": result.sealed_search_latency_ms,
+            "merge_latency_ms": result.merge_latency_ms,
+            "rerank_latency_ms": 0.0,
+            "materialization_latency_ms": 0.0,
+        }
 
     def query_exact_hybrid(
         self,
@@ -122,22 +195,27 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
         snapshot_paths, _watermark = self._query_snapshot(shard_id=shard_id)
         result = run_hybrid_search(
             inputs=HybridSearchInputs(query_vector=query_vector, top_k=top_k, filters=filters),
-            mutable_search=lambda vector, limit, filter_fn, candidate_ids: self.query_executor.search_exact(
-                vector,
-                top_k=limit,
-                filter_fn=filter_fn,
-                candidate_ids=candidate_ids,
+            mutable_search=lambda vector, limit, filter_fn, candidate_ids: (
+                self.query_executor.search_exact(
+                    vector,
+                    top_k=limit,
+                    filter_fn=filter_fn,
+                    candidate_ids=candidate_ids,
+                )
             ),
-            sealed_search=lambda vector, limit, sealed_filters, candidate_ids: self._query_sealed_exactish(
-                vector,
-                top_k=limit,
-                filters=sealed_filters,
-                shard_id=shard_id,
-                candidate_ids=candidate_ids,
-                snapshot_paths=snapshot_paths,
+            sealed_search=lambda vector, limit, sealed_filters, candidate_ids: (
+                self._query_sealed_exactish(
+                    vector,
+                    top_k=limit,
+                    filters=sealed_filters,
+                    shard_id=shard_id,
+                    candidate_ids=candidate_ids,
+                    snapshot_paths=snapshot_paths,
+                )
             ),
             mode="exact",
         )
+        self._record_hybrid_trace(mode="exact-hybrid", result=result, top_k=top_k, filters=filters)
         return [item.vector_id for item in result.ranked_hits]
 
     def query_compressed_hybrid(
@@ -152,20 +230,27 @@ class ShowcaseLocalDatabase(LocalVectorDatabase):
         snapshot_paths, _watermark = self._query_snapshot(shard_id=shard_id)
         result = run_hybrid_search(
             inputs=HybridSearchInputs(query_vector=query_vector, top_k=top_k, filters=filters),
-            mutable_search=lambda vector, limit, filter_fn, candidate_ids: self.query_executor.search_compressed(
-                vector,
-                top_k=limit,
-                filter_fn=filter_fn,
-                candidate_ids=candidate_ids,
+            mutable_search=lambda vector, limit, filter_fn, candidate_ids: (
+                self.query_executor.search_compressed(
+                    vector,
+                    top_k=limit,
+                    filter_fn=filter_fn,
+                    candidate_ids=candidate_ids,
+                )
             ),
-            sealed_search=lambda vector, limit, sealed_filters, candidate_ids: self._query_sealed_compressed(
-                vector,
-                top_k=limit,
-                filters=sealed_filters,
-                shard_id=shard_id,
-                candidate_ids=candidate_ids,
-                snapshot_paths=snapshot_paths,
+            sealed_search=lambda vector, limit, sealed_filters, candidate_ids: (
+                self._query_sealed_compressed(
+                    vector,
+                    top_k=limit,
+                    filters=sealed_filters,
+                    shard_id=shard_id,
+                    candidate_ids=candidate_ids,
+                    snapshot_paths=snapshot_paths,
+                )
             ),
             mode="compressed",
+        )
+        self._record_hybrid_trace(
+            mode="compressed-hybrid", result=result, top_k=top_k, filters=filters
         )
         return [item.vector_id for item in result.ranked_hits]

--- a/src/recalllayer/engine/showcase_rerank_db.py
+++ b/src/recalllayer/engine/showcase_rerank_db.py
@@ -4,19 +4,19 @@ from typing import Any
 
 from recalllayer.engine.hybrid_core import rerank_hybrid_candidates
 from recalllayer.engine.showcase_db import ShowcaseLocalDatabase
-from recalllayer.engine.sealed_segments import SegmentReader
 
 
 class ShowcaseRerankDatabase(ShowcaseLocalDatabase):
     """Showcase facade with a simple rerank stage for hybrid compressed queries."""
 
-    def _sealed_vector_map(self, *, shard_id: str = "shard-0") -> dict[str, tuple[list[float], dict[str, Any]]]:
+    def _sealed_vector_map(
+        self, *, shard_id: str = "shard-0"
+    ) -> dict[str, tuple[list[float], dict[str, Any]]]:
         vectors: dict[str, tuple[list[float], dict[str, Any]]] = {}
-        for path in self._segment_paths(shard_id=shard_id):
-            reader = SegmentReader(path)
-            for indexed in reader.iter_indexed_vectors():
-                reconstructed = (indexed.encoded.codes.astype("float32") * indexed.encoded.scale).tolist()
-                vectors[indexed.vector_id] = (reconstructed, indexed.metadata)
+        for vector_id, reconstructed, metadata in self._decoded_segment_payloads(
+            self._segment_paths(shard_id=shard_id)
+        ):
+            vectors[vector_id] = (reconstructed, metadata)
         return vectors
 
     def query_compressed_reranked_hybrid(
@@ -38,19 +38,29 @@ class ShowcaseRerankDatabase(ShowcaseLocalDatabase):
         reranked = rerank_hybrid_candidates(
             candidate_ids=candidate_ids,
             top_k=top_k,
-            mutable_exact_search=lambda vector, limit, filter_fn, restricted_ids: self.query_executor.search_exact(
-                vector,
-                top_k=limit,
-                filter_fn=filter_fn,
-                candidate_ids=restricted_ids,
+            mutable_exact_search=lambda vector, limit, filter_fn, restricted_ids: (
+                self.query_executor.search_exact(
+                    vector,
+                    top_k=limit,
+                    filter_fn=filter_fn,
+                    candidate_ids=restricted_ids,
+                )
             ),
-            sealed_exact_search=lambda vector, limit, sealed_filters, restricted_ids: self._query_sealed_exactish(
-                vector,
-                top_k=limit,
-                filters=sealed_filters,
-                shard_id=shard_id,
-                candidate_ids=restricted_ids,
+            sealed_exact_search=lambda vector, limit, sealed_filters, restricted_ids: (
+                self._query_sealed_exactish(
+                    vector,
+                    top_k=limit,
+                    filters=sealed_filters,
+                    shard_id=shard_id,
+                    candidate_ids=restricted_ids,
+                )
             ),
             query_vector=query_vector,
         )
+        trace = self.last_query_trace()
+        trace["mode"] = "compressed-reranked-hybrid"
+        trace["rerank_candidate_count"] = len(candidate_ids)
+        trace["rerank_latency_ms"] = reranked.rerank_latency_ms
+        trace["result_count"] = len(reranked.final_hits)
+        self._last_query_trace = trace
         return [candidate.vector_id for candidate in reranked.final_hits]

--- a/src/recalllayer/engine/showcase_scored_db.py
+++ b/src/recalllayer/engine/showcase_scored_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from time import perf_counter
 from typing import Any
 
 from recalllayer.engine.showcase_rerank_db import ShowcaseRerankDatabase
@@ -28,7 +29,9 @@ class ShowcaseScoredDatabase(ShowcaseRerankDatabase):
         filters: dict[str, Any] | None = None,
         shard_id: str = "shard-0",
     ) -> list[Candidate]:
-        ids = self.query_compressed_hybrid(query_vector, top_k=top_k, filters=filters, shard_id=shard_id)
+        ids = self.query_compressed_hybrid(
+            query_vector, top_k=top_k, filters=filters, shard_id=shard_id
+        )
         return self._materialize_hits(ids=ids, query_vector=query_vector, shard_id=shard_id)
 
     def query_compressed_reranked_hybrid_hits(
@@ -56,11 +59,16 @@ class ShowcaseScoredDatabase(ShowcaseRerankDatabase):
         query_vector: list[float],
         shard_id: str,
     ) -> list[Candidate]:
+        materialize_start = perf_counter()
         sealed_vectors = self._sealed_vector_map(shard_id=shard_id)
         hits: list[Candidate] = []
         for vector_id in ids:
             mutable_entry = self.mutable_buffer.get(vector_id)
-            if mutable_entry is not None and not mutable_entry.record.is_deleted and mutable_entry.embedding is not None:
+            if (
+                mutable_entry is not None
+                and not mutable_entry.record.is_deleted
+                and mutable_entry.embedding is not None
+            ):
                 vector = mutable_entry.embedding
                 metadata = mutable_entry.metadata
             else:
@@ -68,7 +76,10 @@ class ShowcaseScoredDatabase(ShowcaseRerankDatabase):
                 if sealed_payload is None:
                     continue
                 vector, metadata = sealed_payload
-            score = float(sum(a * b for a, b in zip(query_vector, vector)))
+            score = float(sum(a * b for a, b in zip(query_vector, vector, strict=True)))
             hits.append(Candidate(vector_id=vector_id, score=score, metadata=metadata))
         hits.sort(key=lambda item: item.score, reverse=True)
+        trace = self.last_query_trace()
+        trace["materialization_latency_ms"] = (perf_counter() - materialize_start) * 1000.0
+        self._last_query_trace = trace
         return hits

--- a/tests/unit/test_mini_harness.py
+++ b/tests/unit/test_mini_harness.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from recalllayer.benchmark.mini_harness import run_mini_harness
 from recalllayer.engine.local_db import LocalVectorDatabase
+from recalllayer.engine.showcase_scored_db import ShowcaseScoredDatabase
 
 
 def test_mini_harness_runs_on_local_db(tmp_path: Path) -> None:
@@ -14,3 +15,19 @@ def test_mini_harness_runs_on_local_db(tmp_path: Path) -> None:
     assert result.recall_at_1 == 1.0
     assert result.exact_elapsed_ms >= 0.0
     assert result.compressed_elapsed_ms >= 0.0
+
+
+def test_mini_harness_tracks_hybrid_trace_and_cache_stats(tmp_path: Path) -> None:
+    db = ShowcaseScoredDatabase(collection_id="documents", root_dir=tmp_path)
+    db.upsert(vector_id="a", embedding=[1.0, 0.0], metadata={"region": "us"})
+    db.upsert(vector_id="b", embedding=[0.0, 1.0], metadata={"region": "ca"})
+    db.flush_mutable(segment_id="seg-1", generation=1)
+
+    result = run_mini_harness(db, [[1.0, 0.0], [1.0, 0.0]], top_k=1)
+
+    assert result.exact.path_name == "exact-hybrid"
+    assert result.compressed.path_name == "compressed-hybrid"
+    assert result.reranked is not None
+    assert result.compressed.trace["candidate_generation_count"] >= 1.0
+    assert result.compressed.cache_stats["indexed_cache"]["hits"] >= 1
+    assert result.reranked.trace["rerank_latency_ms"] >= 0.0

--- a/tests/unit/test_proof_pack.py
+++ b/tests/unit/test_proof_pack.py
@@ -9,7 +9,11 @@ def test_proof_pack_builds_rows_with_exact_baselines() -> None:
     assert exact_rows
     assert all(row.recall_at_1 == 1.0 for row in exact_rows)
     assert all(row.recall_at_10 == 1.0 for row in exact_rows)
+    assert all(row.backend == "scalar-quantizer" for row in rows)
 
     markdown = render_proof_markdown(rows)
-    assert "| Fixture | Query path | Backend | Latency ms | Recall@1 | Recall@10 | Note |" in markdown
-    assert "turboquant-adapter" in markdown
+    assert (
+        "| Fixture | Query path | Backend | Latency ms | Recall@1 | Recall@10 | "
+        "Cache hit rate | File reads | Decode loads | Candidates | Rerank ms | Note |" in markdown
+    )
+    assert "compressed-reranked-hybrid" in markdown

--- a/tests/unit/test_showcase_runner.py
+++ b/tests/unit/test_showcase_runner.py
@@ -4,4 +4,4 @@ from recalllayer.benchmark.showcase_runner import run_showcase_benchmark
 def test_showcase_benchmark_runner_returns_rows() -> None:
     artifacts = run_showcase_benchmark(root_dir=".test_showcase_benchmark_db")
     assert artifacts.rows
-    assert artifacts.rows[0].name == "showcase-scored-db"
+    assert artifacts.rows[0].name == "showcase-scored-db:exact-hybrid"

--- a/tests/unit/test_showcase_scored_db.py
+++ b/tests/unit/test_showcase_scored_db.py
@@ -9,9 +9,52 @@ def test_showcase_scored_db_returns_scores_and_metadata(tmp_path: Path) -> None:
     db.upsert(vector_id="b", embedding=[0.0, 1.0], metadata={"region": "ca"})
     db.flush_mutable(segment_id="seg-1", generation=1)
 
-    hits = db.query_compressed_reranked_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    hits = db.query_compressed_reranked_hybrid_hits(
+        [1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}}
+    )
 
     assert hits
     assert hits[0].vector_id == "a"
     assert hits[0].metadata["region"] == "us"
     assert hits[0].score > 0.0
+
+
+def test_showcase_scored_db_repeated_hybrid_paths_hit_segment_cache(tmp_path: Path) -> None:
+    db = ShowcaseScoredDatabase(collection_id="documents", root_dir=tmp_path)
+    db.upsert(vector_id="a", embedding=[1.0, 0.0], metadata={"region": "us"})
+    db.upsert(vector_id="b", embedding=[0.8, 0.2], metadata={"region": "us"})
+    db.flush_mutable(segment_id="seg-1", generation=1)
+
+    db.clear_segment_caches()
+    db.reset_segment_cache_stats()
+    db.query_exact_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    first_exact = db.segment_cache_stats()
+    db.query_exact_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    second_exact = db.segment_cache_stats()
+
+    assert first_exact["segment_reads"]["decode_loads"] == 1
+    assert second_exact["decoded_cache"]["hits"] >= 1
+    assert second_exact["segment_reads"]["decode_loads"] == 1
+
+    db.clear_segment_caches()
+    db.reset_segment_cache_stats()
+    db.query_compressed_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    first_compressed = db.segment_cache_stats()
+    db.query_compressed_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    second_compressed = db.segment_cache_stats()
+
+    assert first_compressed["segment_reads"]["decode_loads"] == 1
+    assert second_compressed["indexed_cache"]["hits"] >= 1
+    assert second_compressed["segment_reads"]["decode_loads"] == 1
+
+    db.clear_segment_caches()
+    db.reset_segment_cache_stats()
+    db.query_compressed_reranked_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    first_reranked = db.segment_cache_stats()
+    db.query_compressed_reranked_hybrid_hits([1.0, 0.0], top_k=2, filters={"region": {"eq": "us"}})
+    second_reranked = db.segment_cache_stats()
+
+    assert first_reranked["segment_reads"]["decode_loads"] == 1
+    assert second_reranked["indexed_cache"]["hits"] >= 1
+    assert second_reranked["decoded_cache"]["hits"] >= 1
+    assert second_reranked["segment_reads"]["decode_loads"] == 1


### PR DESCRIPTION
## Overview

Sprint 4 makes the sealed-query cache actually count on the benchmarked paths, adds cache/timing instrumentation, and reruns the benchmark with honest results.

## What this PR does

### 1. Fixes cache usage on benchmarked paths
- Ensures exact-hybrid, compressed-hybrid, and compressed-reranked-hybrid paths benefit from cached sealed segment reads/decodes
- Deepens the effective cache behavior on the benchmark path so repeated queries avoid repeated file reads and decode work
- Adds visible cache stats/counters to benchmark outputs

### 2. Adds benchmark instrumentation
- Captures cache hit rate
- Captures file reads and decode loads
- Captures candidate generation count and rerank latency
- Wires these through the mini harness / showcase runner benchmark flow

### 3. Keeps canonical benchmark honest
- TurboQuantAdapter remains experimental and is intentionally excluded from the canonical sprint-4 cache summary because its geometry/scoring mismatch is not fixed here
- Canonical benchmark summary focuses on scalar quantizers that are behaving correctly

### 4. Reruns benchmark and records results
- Adds 
- Adds 
- Adds 
- Adds 

## Benchmark result summary

Representative subset (, ) shows the cache is now materially reducing sealed-query overhead:

- file reads drop from **12–24 per run to 1**
- decode loads drop from **12–24 per run to 1**
- cache hit rate lands around **0.846–0.920**

Examples:
- : **2.865 ms -> 0.682 ms**
- : **3.025 ms -> 1.088 ms**
- : **4.228 ms -> 1.313 ms**

- : **0.909 ms -> 0.433 ms**
- : **0.877 ms -> 0.486 ms**
- : **1.293 ms -> 0.661 ms**

## Honest conclusion
- The cache path is fixed and clearly helping
- Scalar quantizers remain healthy
- TurboQuantAdapter is still not benchmark-canonical
- Compressed+rereank is improved substantially but still does not beat exact-hybrid in the representative subset; this sprint fixes the I/O/decode bottleneck but does not yet prove compressed+rereank wins overall latency

## Validation
- Full test suite passing locally after changes
- Benchmark summary/doc committed with results