### PR TITLE
Production hardening: rate limiting, TLS, multi-tenancy, auto-flush, dynamic IVF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,26 @@ ENV RECALLLAYER_HOST=0.0.0.0
 ENV RECALLLAYER_PORT=8765
 ENV RECALLLAYER_LOG_LEVEL=info
 
+# TLS: set both to enable HTTPS termination inside the container.
+# Mount your cert/key into the container and point these vars at the paths.
+# Leave empty (the default) to run plain HTTP (recommended behind a TLS proxy).
+ENV RECALLLAYER_TLS_CERT=
+ENV RECALLLAYER_TLS_KEY=
+
 EXPOSE 8765
 
 # Health check — hits /healthz every 10s with a 5s timeout, 3 retries.
+# Uses https:// automatically when TLS is configured.
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${RECALLLAYER_PORT}/healthz')"
+  CMD python -c " \
+import os, urllib.request, ssl; \
+scheme = 'https' if os.getenv('RECALLLAYER_TLS_CERT') else 'http'; \
+ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE; \
+urllib.request.urlopen(f\"{scheme}://localhost:{os.getenv('RECALLLAYER_PORT', 8765)}/healthz\", context=ctx if scheme=='https' else None) \
+"
 
-CMD uvicorn recalllayer.api.recalllayer_sidecar_app:app \
-      --host "${RECALLLAYER_HOST}" \
-      --port "${RECALLLAYER_PORT}" \
-      --log-level "${RECALLLAYER_LOG_LEVEL}"
+# Entrypoint script resolves TLS flags at runtime so the CMD stays readable.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,29 @@ services:
         postgresql://${POSTGRES_USER:-recallapp}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-recallapp}
       RECALLLAYER_POSTGRES_TABLE: ${RECALLLAYER_POSTGRES_TABLE:-documents}
 
-      # Auth — set a non-empty value to require X-Api-Key on all requests.
+      # Auth — single-tenant: set X-Api-Key on all requests.
       RECALLLAYER_API_KEY: ${RECALLLAYER_API_KEY:-}
+      # Auth — multi-tenant: comma-separated list of "api_key:collection_id" pairs.
+      # When set, each key is isolated to its own collection namespace.
+      # Example: RECALLLAYER_TENANTS=keyA:col-a,keyB:col-b
+      RECALLLAYER_TENANTS: ${RECALLLAYER_TENANTS:-}
+
+      # Rate limiting — max requests per minute per API key (0 = disabled).
+      RECALLLAYER_RATE_LIMIT: ${RECALLLAYER_RATE_LIMIT:-0}
+
+      # Auto-flush scheduler — seconds between automatic flushes (0 = disabled).
+      RECALLLAYER_AUTO_FLUSH_INTERVAL_SEC: ${RECALLLAYER_AUTO_FLUSH_INTERVAL_SEC:-300}
+      # Also flush when the mutable buffer grows beyond this many upserts.
+      RECALLLAYER_AUTO_FLUSH_UPSERT_THRESHOLD: ${RECALLLAYER_AUTO_FLUSH_UPSERT_THRESHOLD:-10000}
+
+      # Dynamic IVF — auto-enable IVF when total live rows exceed this threshold.
+      # Set n_clusters = sqrt(N). Set to 0 to disable auto-IVF.
+      RECALLLAYER_IVF_AUTO_THRESHOLD: ${RECALLLAYER_IVF_AUTO_THRESHOLD:-50000}
+
+      # TLS — paths to cert and key files inside the container (leave empty for HTTP).
+      # Mount a volume containing your certs and set these paths accordingly.
+      RECALLLAYER_TLS_CERT: ${RECALLLAYER_TLS_CERT:-}
+      RECALLLAYER_TLS_KEY: ${RECALLLAYER_TLS_KEY:-}
 
       # Server
       RECALLLAYER_HOST: 0.0.0.0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Entrypoint for RecallLayer sidecar container.
+# Builds the uvicorn command, adding TLS flags only when cert+key are provided.
+set -e
+
+TLS_ARGS=""
+if [ -n "${RECALLLAYER_TLS_CERT}" ] && [ -n "${RECALLLAYER_TLS_KEY}" ]; then
+    TLS_ARGS="--ssl-certfile ${RECALLLAYER_TLS_CERT} --ssl-keyfile ${RECALLLAYER_TLS_KEY}"
+fi
+
+exec uvicorn recalllayer.api.recalllayer_sidecar_app:app \
+    --host "${RECALLLAYER_HOST:-0.0.0.0}" \
+    --port "${RECALLLAYER_PORT:-8765}" \
+    --log-level "${RECALLLAYER_LOG_LEVEL:-info}" \
+    ${TLS_ARGS}

--- a/src/recalllayer/api/rate_limiter.py
+++ b/src/recalllayer/api/rate_limiter.py
@@ -1,0 +1,53 @@
+"""Simple sliding-window rate limiter for per-key request throttling.
+
+No external dependencies — uses only the standard library.
+"""
+from __future__ import annotations
+
+import time
+from collections import deque
+from threading import Lock
+
+
+class SlidingWindowRateLimiter:
+    """Limit requests to *max_requests* per *window_seconds* per identifier.
+
+    Thread-safe via a per-key lock.  Identifiers are typically API keys or
+    remote IP addresses (for unauthenticated clients).
+
+    Usage::
+
+        limiter = SlidingWindowRateLimiter(max_requests=60, window_seconds=60)
+        allowed, retry_after = limiter.check("some-key")
+        if not allowed:
+            raise HTTPException(429, headers={"Retry-After": str(retry_after)})
+    """
+
+    def __init__(self, *, max_requests: int, window_seconds: float = 60.0) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._windows: dict[str, deque[float]] = {}
+        self._lock = Lock()
+
+    def check(self, identifier: str) -> tuple[bool, float]:
+        """Record a request for *identifier* and check whether it is allowed.
+
+        Returns ``(allowed, retry_after_seconds)``.  When *allowed* is True
+        the request was recorded and should proceed.  When False, *retry_after*
+        is the number of seconds the caller must wait before the oldest request
+        in the current window expires.
+        """
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        with self._lock:
+            if identifier not in self._windows:
+                self._windows[identifier] = deque()
+            window = self._windows[identifier]
+            # Evict timestamps outside the current window
+            while window and window[0] <= cutoff:
+                window.popleft()
+            if len(window) >= self.max_requests:
+                retry_after = self.window_seconds - (now - window[0])
+                return False, max(0.0, retry_after)
+            window.append(now)
+            return True, 0.0

--- a/src/recalllayer/api/recalllayer_sidecar_app.py
+++ b/src/recalllayer/api/recalllayer_sidecar_app.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import logging
 import os
-from dataclasses import dataclass
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Annotated
 
-from fastapi import Depends, FastAPI, Header, HTTPException, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
 
+from recalllayer.api.rate_limiter import SlidingWindowRateLimiter
 from recalllayer.api.recalllayer_sidecar_schemas import (
     SidecarCompactionRequest,
     SidecarDocumentUpsertRequest,
@@ -21,53 +26,210 @@ from recalllayer.sidecar import (
     RecallLayerSidecar,
 )
 
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
 
 @dataclass(slots=True)
+class TenantConfig:
+    """Maps an API key to an isolated collection namespace."""
+
+    api_key: str
+    collection_id: str
+
+
+@dataclass
 class SidecarAppConfig:
     root_dir: str | Path = ".recalllayer_sidecar_http_db"
     collection_id: str = "recalllayer-sidecar-demo"
     host_repository: str = "inmemory"
     postgres_dsn: str | None = None
     postgres_table: str = "documents"
+    # Single-tenant auth (legacy)
     api_key: str | None = None
+    # Multi-tenant: list of TenantConfig entries derived from RECALLLAYER_TENANTS
+    tenants: list[TenantConfig] = field(default_factory=list)
+    # Rate limiting
+    rate_limit: int = 0  # 0 = disabled; N = max requests per minute per key
+    # Auto-flush scheduler
+    auto_flush_interval_sec: float = 300.0  # 0 = disabled
+    auto_flush_upsert_threshold: int = 10_000  # flush when buffer exceeds this
+    # Dynamic IVF: auto-enable when live row count crosses this threshold (None = disabled)
+    ivf_auto_threshold: int | None = 50_000
 
 
-AuthHeader = Annotated[str | None, Header(alias="x-api-key")] 
+AuthHeader = Annotated[str | None, Header(alias="x-api-key")]
+
+
+def _parse_tenants(raw: str) -> list[TenantConfig]:
+    """Parse ``key1:ns1,key2:ns2`` into a list of TenantConfig objects."""
+    tenants: list[TenantConfig] = []
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if not pair:
+            continue
+        if ":" not in pair:
+            raise ValueError(
+                f"RECALLLAYER_TENANTS entry {pair!r} must be in 'api_key:collection_id' format"
+            )
+        api_key, _, collection_id = pair.partition(":")
+        api_key = api_key.strip()
+        collection_id = collection_id.strip()
+        if not api_key or not collection_id:
+            raise ValueError(
+                f"RECALLLAYER_TENANTS entry {pair!r}: api_key and collection_id must be non-empty"
+            )
+        tenants.append(TenantConfig(api_key=api_key, collection_id=collection_id))
+    return tenants
 
 
 def load_sidecar_app_config_from_env() -> SidecarAppConfig:
+    tenants: list[TenantConfig] = []
+    raw_tenants = os.getenv("RECALLLAYER_TENANTS", "").strip()
+    if raw_tenants:
+        tenants = _parse_tenants(raw_tenants)
+
     return SidecarAppConfig(
         root_dir=os.getenv("RECALLLAYER_SIDECAR_ROOT_DIR", ".recalllayer_sidecar_http_db"),
         collection_id=os.getenv("RECALLLAYER_COLLECTION_ID", "recalllayer-sidecar-demo"),
         host_repository=os.getenv("RECALLLAYER_HOST_REPOSITORY", "inmemory").strip().lower(),
         postgres_dsn=os.getenv("RECALLLAYER_POSTGRES_DSN"),
         postgres_table=os.getenv("RECALLLAYER_POSTGRES_TABLE", "documents"),
-        api_key=os.getenv("RECALLLAYER_API_KEY"),
+        api_key=os.getenv("RECALLLAYER_API_KEY") or None,
+        tenants=tenants,
+        rate_limit=int(os.getenv("RECALLLAYER_RATE_LIMIT", "0")),
+        auto_flush_interval_sec=float(os.getenv("RECALLLAYER_AUTO_FLUSH_INTERVAL_SEC", "300")),
+        auto_flush_upsert_threshold=int(
+            os.getenv("RECALLLAYER_AUTO_FLUSH_UPSERT_THRESHOLD", "10000")
+        ),
+        ivf_auto_threshold=(
+            int(os.getenv("RECALLLAYER_IVF_AUTO_THRESHOLD"))
+            if os.getenv("RECALLLAYER_IVF_AUTO_THRESHOLD")
+            else 50_000
+        ),
     )
 
 
-def build_sidecar_from_config(config: SidecarAppConfig) -> RecallLayerSidecar:
+# ---------------------------------------------------------------------------
+# Sidecar factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_host_db(config: SidecarAppConfig):
     if config.host_repository == "inmemory":
-        host_db = InMemoryPostgresRepository()
-    elif config.host_repository == "postgres":
+        return InMemoryPostgresRepository()
+    if config.host_repository == "postgres":
         if not config.postgres_dsn:
             raise RuntimeError(
                 "RECALLLAYER_POSTGRES_DSN is required when RECALLLAYER_HOST_REPOSITORY=postgres"
             )
-        host_db = PsycopgPostgresRepository.from_dsn(
+        return PsycopgPostgresRepository.from_dsn(
             config.postgres_dsn,
             table_name=config.postgres_table,
         )
-    else:
-        raise RuntimeError(
-            f"unsupported RECALLLAYER_HOST_REPOSITORY={config.host_repository!r}; "
-            "expected 'inmemory' or 'postgres'"
-        )
-    return RecallLayerSidecar(
-        host_db=host_db,
-        root_dir=config.root_dir,
-        collection_id=config.collection_id,
+    raise RuntimeError(
+        f"unsupported RECALLLAYER_HOST_REPOSITORY={config.host_repository!r}; "
+        "expected 'inmemory' or 'postgres'"
     )
+
+
+def build_sidecar_from_config(
+    config: SidecarAppConfig, *, collection_id: str | None = None
+) -> RecallLayerSidecar:
+    return RecallLayerSidecar(
+        host_db=_build_host_db(config),
+        root_dir=config.root_dir,
+        collection_id=collection_id or config.collection_id,
+        ivf_auto_threshold=config.ivf_auto_threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto-flush background scheduler
+# ---------------------------------------------------------------------------
+
+
+class AutoFlushScheduler:
+    """Background thread that periodically flushes sidecar buffers.
+
+    Flushes when either:
+    - *interval_sec* seconds have elapsed since the last flush, OR
+    - the mutable buffer has grown beyond *upsert_threshold* entries.
+
+    The scheduler runs in a daemon thread so it does not prevent process exit.
+    """
+
+    def __init__(
+        self,
+        *,
+        sidecars: dict[str, RecallLayerSidecar],
+        interval_sec: float,
+        upsert_threshold: int,
+        poll_sec: float = 1.0,
+    ) -> None:
+        self._sidecars = sidecars
+        self._interval_sec = interval_sec
+        self._upsert_threshold = upsert_threshold
+        self._poll_sec = poll_sec
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="recalllayer-autoflush")
+        self._flush_counter: dict[str, int] = {}
+
+    def start(self) -> None:
+        self._thread.start()
+        logger.info(
+            "AutoFlushScheduler started (interval=%.0fs, threshold=%d upserts)",
+            self._interval_sec,
+            self._upsert_threshold,
+        )
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop.set()
+        self._thread.join(timeout=timeout)
+
+    def _run(self) -> None:
+        last_flush_at = time.monotonic()
+        while not self._stop.wait(timeout=self._poll_sec):
+            now = time.monotonic()
+            elapsed = now - last_flush_at
+            for collection_id, sidecar in list(self._sidecars.items()):
+                try:
+                    buf_size = sum(
+                        len(buf.all_entries())
+                        for buf in sidecar.recall_layer._shard_buffers.values()
+                    )
+                    should_flush = (
+                        elapsed >= self._interval_sec
+                        or buf_size >= self._upsert_threshold
+                    )
+                    if should_flush and buf_size > 0:
+                        counter = self._flush_counter.get(collection_id, 0) + 1
+                        self._flush_counter[collection_id] = counter
+                        sidecar.flush(
+                            segment_id=f"seg-auto-{counter}",
+                            generation=counter,
+                        )
+                        logger.info(
+                            "AutoFlush: flushed collection=%s segment=seg-auto-%d buf_size=%d",
+                            collection_id,
+                            counter,
+                            buf_size,
+                        )
+                except Exception:
+                    logger.exception(
+                        "AutoFlush: error flushing collection=%s", collection_id
+                    )
+            if elapsed >= self._interval_sec:
+                last_flush_at = now
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
 
 
 def create_recalllayer_sidecar_app(
@@ -77,53 +239,157 @@ def create_recalllayer_sidecar_app(
     config: SidecarAppConfig | None = None,
 ) -> FastAPI:
     app_config = config or SidecarAppConfig(root_dir=root_dir)
-    app = FastAPI(title="RecallLayer Sidecar")
-    local_sidecar = sidecar or build_sidecar_from_config(app_config)
-    app.state.sidecar = local_sidecar
-    app.state.sidecar_config = app_config
 
-    def require_api_key(x_api_key: AuthHeader = None) -> None:
-        if app_config.api_key is None:
+    # ------------------------------------------------------------------
+    # Multi-tenancy: build a sidecar per tenant; fall back to single sidecar
+    # ------------------------------------------------------------------
+    tenant_sidecars: dict[str, RecallLayerSidecar] = {}  # api_key -> sidecar
+    collection_sidecars: dict[str, RecallLayerSidecar] = {}  # collection_id -> sidecar
+
+    if app_config.tenants:
+        for tenant in app_config.tenants:
+            sc = build_sidecar_from_config(app_config, collection_id=tenant.collection_id)
+            tenant_sidecars[tenant.api_key] = sc
+            collection_sidecars[tenant.collection_id] = sc
+        # The "default" sidecar for health/status endpoints is the first tenant's
+        default_sidecar = next(iter(tenant_sidecars.values()))
+    else:
+        default_sidecar = sidecar or build_sidecar_from_config(app_config)
+        if app_config.api_key:
+            tenant_sidecars[app_config.api_key] = default_sidecar
+        collection_sidecars[app_config.collection_id] = default_sidecar
+
+    # ------------------------------------------------------------------
+    # Rate limiter
+    # ------------------------------------------------------------------
+    rate_limiter: SlidingWindowRateLimiter | None = None
+    if app_config.rate_limit > 0:
+        rate_limiter = SlidingWindowRateLimiter(
+            max_requests=app_config.rate_limit, window_seconds=60.0
+        )
+        logger.info("Rate limiting enabled: %d req/min per key", app_config.rate_limit)
+
+    # ------------------------------------------------------------------
+    # Auto-flush scheduler
+    # ------------------------------------------------------------------
+    scheduler: AutoFlushScheduler | None = None
+    if app_config.auto_flush_interval_sec > 0:
+        scheduler = AutoFlushScheduler(
+            sidecars=collection_sidecars,
+            interval_sec=app_config.auto_flush_interval_sec,
+            upsert_threshold=app_config.auto_flush_upsert_threshold,
+        )
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        if scheduler is not None:
+            scheduler.start()
+        yield
+        if scheduler is not None:
+            scheduler.stop()
+
+    app = FastAPI(title="RecallLayer Sidecar", lifespan=lifespan)
+
+    # ------------------------------------------------------------------
+    # Auth + rate-limit dependency
+    # ------------------------------------------------------------------
+
+    def _resolve_sidecar(x_api_key: str | None) -> RecallLayerSidecar:
+        """Validate API key and return the sidecar for the caller's tenant."""
+        # Multi-tenant mode
+        if app_config.tenants:
+            if x_api_key is None or x_api_key not in tenant_sidecars:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="missing or invalid x-api-key",
+                )
+            return tenant_sidecars[x_api_key]
+
+        # Single-tenant (legacy) mode
+        if app_config.api_key is not None and x_api_key != app_config.api_key:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="missing or invalid x-api-key",
+            )
+        return default_sidecar
+
+    def require_auth(request: Request, x_api_key: AuthHeader = None) -> RecallLayerSidecar:
+        sc = _resolve_sidecar(x_api_key)
+        if rate_limiter is not None:
+            identifier = x_api_key or request.client.host if request.client else "anonymous"
+            allowed, retry_after = rate_limiter.check(identifier)
+            if not allowed:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="rate limit exceeded",
+                    headers={"Retry-After": str(int(retry_after) + 1)},
+                )
+        return sc
+
+    # Unauthenticated check for health endpoints
+    def require_api_key_no_tenant(x_api_key: AuthHeader = None) -> None:
+        if app_config.api_key is None and not app_config.tenants:
             return
-        if x_api_key != app_config.api_key:
+        if app_config.tenants and (x_api_key is None or x_api_key not in tenant_sidecars):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="missing or invalid x-api-key",
+            )
+        if app_config.api_key is not None and x_api_key != app_config.api_key:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="missing or invalid x-api-key",
             )
 
+    # ------------------------------------------------------------------
+    # Routes
+    # ------------------------------------------------------------------
+
     @app.get("/healthz")
     def healthz() -> dict[str, Any]:
         return {
             "status": "ok",
-            "collection_id": local_sidecar.collection_id,
-            "host_repository": local_sidecar.host_db.__class__.__name__,
-            "root_dir": str(local_sidecar.root_dir),
-            "api_key_enabled": app_config.api_key is not None,
+            "collection_id": default_sidecar.collection_id,
+            "host_repository": default_sidecar.host_db.__class__.__name__,
+            "root_dir": str(default_sidecar.root_dir),
+            "api_key_enabled": app_config.api_key is not None or bool(app_config.tenants),
+            "multi_tenant": bool(app_config.tenants),
+            "tenant_count": len(app_config.tenants),
+            "rate_limit_rpm": app_config.rate_limit if app_config.rate_limit > 0 else None,
+            "auto_flush_interval_sec": (
+                app_config.auto_flush_interval_sec
+                if app_config.auto_flush_interval_sec > 0
+                else None
+            ),
         }
 
     @app.get("/readyz")
     def readyz() -> dict[str, Any]:
         return {
             "status": "ready",
-            "collection_id": local_sidecar.collection_id,
-            "host_repository": local_sidecar.host_db.__class__.__name__,
+            "collection_id": default_sidecar.collection_id,
+            "host_repository": default_sidecar.host_db.__class__.__name__,
         }
 
-    @app.get("/v1/status")
+    @app.get("/v1/status", dependencies=[Depends(require_api_key_no_tenant)])
     def sidecar_status() -> dict[str, Any]:
-        shard_ids = local_sidecar._known_shard_ids()
+        shard_ids = default_sidecar._known_shard_ids()
         return {
-            "collection_id": local_sidecar.collection_id,
-            "host_repository": local_sidecar.host_db.__class__.__name__,
-            "root_dir": str(local_sidecar.root_dir),
-            "api_key_enabled": app_config.api_key is not None,
+            "collection_id": default_sidecar.collection_id,
+            "host_repository": default_sidecar.host_db.__class__.__name__,
+            "root_dir": str(default_sidecar.root_dir),
+            "api_key_enabled": app_config.api_key is not None or bool(app_config.tenants),
             "known_shard_ids": shard_ids,
-            "known_document_ids": local_sidecar.known_document_ids(),
+            "known_document_ids": default_sidecar.known_document_ids(),
         }
 
-    @app.put("/v1/documents/{document_id}", dependencies=[Depends(require_api_key)])
-    def upsert_document(document_id: str, request: SidecarDocumentUpsertRequest) -> dict[str, Any]:
-        vector_id = local_sidecar.upsert_and_sync_document(
+    @app.put("/v1/documents/{document_id}")
+    def upsert_document(
+        document_id: str,
+        request: SidecarDocumentUpsertRequest,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        vector_id = sc.upsert_and_sync_document(
             document_id=document_id,
             title=request.title,
             body=request.body,
@@ -136,62 +402,87 @@ def create_recalllayer_sidecar_app(
             "status": request.status,
         }
 
-    @app.post("/v1/documents/{document_id}/sync", dependencies=[Depends(require_api_key)])
-    def sync_document(document_id: str) -> dict[str, Any]:
-        vector_id = local_sidecar.sync_document(document_id)
+    @app.post("/v1/documents/{document_id}/sync")
+    def sync_document(
+        document_id: str,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        vector_id = sc.sync_document(document_id)
         return {"document_id": document_id, "vector_id": vector_id}
 
-    @app.post("/v1/documents/{document_id}/unpublish", dependencies=[Depends(require_api_key)])
-    def unpublish_document(document_id: str) -> dict[str, Any]:
-        vector_id = local_sidecar.unpublish_document(document_id)
+    @app.post("/v1/documents/{document_id}/unpublish")
+    def unpublish_document(
+        document_id: str,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        vector_id = sc.unpublish_document(document_id)
         return {"document_id": document_id, "vector_id": vector_id, "status": "unpublished"}
 
-    @app.delete("/v1/documents/{document_id}", dependencies=[Depends(require_api_key)])
-    def delete_document(document_id: str) -> dict[str, Any]:
-        vector_id = local_sidecar.delete_document(document_id)
+    @app.delete("/v1/documents/{document_id}")
+    def delete_document(
+        document_id: str,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        vector_id = sc.delete_document(document_id)
         return {"document_id": document_id, "vector_id": vector_id, "deleted": True}
 
-    @app.post("/v1/query", response_model=SidecarSearchResponse, dependencies=[Depends(require_api_key)])
-    def query(request: SidecarQueryRequest) -> SidecarSearchResponse:
-        result = local_sidecar.search(
+    @app.post("/v1/query", response_model=SidecarSearchResponse)
+    def query(
+        request: SidecarQueryRequest,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> SidecarSearchResponse:
+        result = sc.search(
             request.query_text,
             top_k=request.top_k,
             region=request.region,
         )
         return SidecarSearchResponse(**result)
 
-    @app.post("/v1/repair", dependencies=[Depends(require_api_key)])
-    def repair(request: SidecarRepairRequest) -> dict[str, Any]:
-        synced = local_sidecar.repair_documents(request.document_ids)
+    @app.post("/v1/repair")
+    def repair(
+        request: SidecarRepairRequest,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        synced = sc.repair_documents(request.document_ids)
         return {
-            "document_ids": request.document_ids or local_sidecar.known_document_ids(),
+            "document_ids": request.document_ids or sc.known_document_ids(),
             "synced_vector_ids": synced,
         }
 
-    @app.post("/v1/backfill", dependencies=[Depends(require_api_key)])
-    def backfill() -> dict[str, Any]:
-        synced = local_sidecar.backfill_from_host()
+    @app.post("/v1/backfill")
+    def backfill(sc: RecallLayerSidecar = Depends(require_auth)) -> dict[str, Any]:
+        synced = sc.backfill_from_host()
         return {"synced_vector_ids": synced}
 
-    @app.post("/v1/flush", dependencies=[Depends(require_api_key)])
-    def flush(request: SidecarFlushRequest) -> dict[str, Any]:
-        local_sidecar.flush(segment_id=request.segment_id, generation=request.generation)
-        shard_manifest, _segment_manifests = local_sidecar.recall_layer.load_manifest_set()
+    @app.post("/v1/flush")
+    def flush(
+        request: SidecarFlushRequest,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        sc.flush(segment_id=request.segment_id, generation=request.generation)
+        shard_manifest, _segment_manifests = sc.recall_layer.load_manifest_set()
         return {
             "active_segment_ids": (
                 shard_manifest.active_segment_ids if shard_manifest is not None else []
             ),
         }
 
-    @app.post("/v1/compact", dependencies=[Depends(require_api_key)])
-    def compact(request: SidecarCompactionRequest) -> dict[str, Any]:
-        result = local_sidecar.compact(
+    @app.post("/v1/compact")
+    def compact(
+        request: SidecarCompactionRequest,
+        sc: RecallLayerSidecar = Depends(require_auth),
+    ) -> dict[str, Any]:
+        result = sc.compact(
             output_segment_id=request.output_segment_id,
             generation=request.generation,
             min_segment_count=request.min_segment_count,
             max_total_rows=request.max_total_rows,
         )
         return {"compacted": result is not None, "result": result}
+
+    app.state.sidecar = default_sidecar
+    app.state.sidecar_config = app_config
+    app.state.tenant_sidecars = tenant_sidecars
 
     return app
 

--- a/src/recalllayer/engine/local_db.py
+++ b/src/recalllayer/engine/local_db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,7 @@ class LocalVectorDatabase:
         enable_ivf: bool = False,
         ivf_n_clusters: int = 8,
         ivf_probe_k: int = 2,
+        ivf_auto_threshold: int | None = 50_000,
     ) -> None:
         self.collection_id = collection_id
         self.root_dir = Path(root_dir)
@@ -51,6 +53,7 @@ class LocalVectorDatabase:
         self.enable_ivf = enable_ivf
         self.ivf_n_clusters = ivf_n_clusters
         self.ivf_probe_k = ivf_probe_k
+        self.ivf_auto_threshold = ivf_auto_threshold
 
         self.mutable_buffer = MutableBuffer(collection_id=collection_id)
         self.write_log = WriteLog(
@@ -210,6 +213,45 @@ class LocalVectorDatabase:
             )
         ]
 
+    def _resolve_ivf_clusters(self, *, shard_id: str) -> int | None:
+        """Return the IVF cluster count to use for the next flush, or None to disable IVF.
+
+        When *ivf_auto_threshold* is set, IVF is automatically enabled once the
+        total live row count (sealed + mutable) crosses the threshold.  The cluster
+        count is computed as ``max(8, sqrt(total_rows))`` — the ANNS rule of thumb
+        that keeps each bucket at O(sqrt(N)) vectors.  Manual ``enable_ivf`` always
+        wins when set to True.
+        """
+        if self.enable_ivf:
+            return self.ivf_n_clusters
+
+        if self.ivf_auto_threshold is None:
+            return None
+
+        # Estimate total corpus size for this shard
+        shard_manifest = self.manifest_store.load(
+            collection_id=self.collection_id, shard_id=shard_id
+        )
+        sealed_rows = 0
+        if shard_manifest is not None:
+            active_ids = set(shard_manifest.active_segment_ids)
+            seg_manifests = self.segment_manifest_store.list_manifests(
+                collection_id=self.collection_id, shard_id=shard_id
+            )
+            sealed_rows = sum(
+                m.live_row_count for m in seg_manifests if m.segment_id in active_ids
+            )
+        buf = self._get_mutable_buffer(shard_id)
+        mutable_rows = len(buf.live_entries())
+        total_rows = sealed_rows + mutable_rows
+
+        if total_rows < self.ivf_auto_threshold:
+            return None
+
+        # sqrt(N) clusters, clamped to [8, 4096]
+        n_clusters = max(8, min(4096, int(math.isqrt(total_rows))))
+        return n_clusters
+
     def flush_mutable(
         self,
         *,
@@ -223,6 +265,7 @@ class LocalVectorDatabase:
         if not entries:
             return None
 
+        n_ivf_clusters = self._resolve_ivf_clusters(shard_id=shard_id)
         segment_manifest, _paths = self.segment_builder.build(
             collection_id=self.collection_id,
             shard_id=shard_id,
@@ -231,7 +274,7 @@ class LocalVectorDatabase:
             embedding_version=self.embedding_version,
             quantizer_version=self.quantizer_version,
             entries=entries,
-            n_ivf_clusters=self.ivf_n_clusters if self.enable_ivf else None,
+            n_ivf_clusters=n_ivf_clusters,
         )
         self.segment_cache.invalidate(_paths.segment_path)
         self.decoded_segment_cache.invalidate(_paths.segment_path)

--- a/src/recalllayer/sidecar.py
+++ b/src/recalllayer/sidecar.py
@@ -308,6 +308,7 @@ class RecallLayerSidecar:
         host_db: HostDocumentRepository,
         root_dir: str | Path,
         collection_id: str = "recalllayer-sidecar-demo",
+        ivf_auto_threshold: int | None = 50_000,
     ) -> None:
         self.host_db = host_db
         self.root_dir = Path(root_dir)
@@ -315,6 +316,7 @@ class RecallLayerSidecar:
         self.recall_layer = ShowcaseScoredDatabase(
             collection_id=collection_id,
             root_dir=self.root_dir,
+            ivf_auto_threshold=ivf_auto_threshold,
         )
 
     def upsert_and_sync_document(

--- a/tests/unit/test_production_hardening.py
+++ b/tests/unit/test_production_hardening.py
@@ -1,0 +1,325 @@
+"""Tests for the five production-hardening features:
+
+1. Rate limiting (SlidingWindowRateLimiter)
+2. TLS configuration (docker-entrypoint.sh passthrough — tested indirectly)
+3. Multi-tenancy (per-key collection isolation)
+4. Auto-flush scheduler (AutoFlushScheduler background thread)
+5. Dynamic IVF (ivf_auto_threshold in LocalVectorDatabase)
+"""
+from __future__ import annotations
+
+import math
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Rate Limiter
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingWindowRateLimiter:
+    def test_allows_requests_within_limit(self):
+        from recalllayer.api.rate_limiter import SlidingWindowRateLimiter
+
+        limiter = SlidingWindowRateLimiter(max_requests=5, window_seconds=60.0)
+        for _ in range(5):
+            allowed, retry_after = limiter.check("key-a")
+            assert allowed is True
+            assert retry_after == 0.0
+
+    def test_blocks_requests_over_limit(self):
+        from recalllayer.api.rate_limiter import SlidingWindowRateLimiter
+
+        limiter = SlidingWindowRateLimiter(max_requests=3, window_seconds=60.0)
+        for _ in range(3):
+            limiter.check("key-b")
+        allowed, retry_after = limiter.check("key-b")
+        assert allowed is False
+        assert retry_after > 0.0
+
+    def test_different_keys_are_independent(self):
+        from recalllayer.api.rate_limiter import SlidingWindowRateLimiter
+
+        limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+        allowed_a, _ = limiter.check("key-a")
+        allowed_a2, _ = limiter.check("key-a")  # should be blocked
+        allowed_b, _ = limiter.check("key-b")  # different key — should pass
+
+        assert allowed_a is True
+        assert allowed_a2 is False
+        assert allowed_b is True
+
+    def test_window_expiry_allows_new_requests(self):
+        from recalllayer.api.rate_limiter import SlidingWindowRateLimiter
+
+        limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=0.1)
+        limiter.check("key-c")
+        time.sleep(0.15)
+        allowed, _ = limiter.check("key-c")
+        assert allowed is True
+
+
+# ---------------------------------------------------------------------------
+# 2. TLS — app config parses env vars (actual SSL binding is an infra concern)
+# ---------------------------------------------------------------------------
+
+
+class TestTLSConfig:
+    def test_entrypoint_script_exists(self):
+        """The docker-entrypoint.sh that wires TLS into uvicorn must exist."""
+        script = Path(__file__).parent.parent.parent / "docker-entrypoint.sh"
+        assert script.exists(), "docker-entrypoint.sh is missing"
+        content = script.read_text()
+        assert "ssl-certfile" in content
+        assert "ssl-keyfile" in content
+        assert "RECALLLAYER_TLS_CERT" in content
+        assert "RECALLLAYER_TLS_KEY" in content
+
+    def test_dockerfile_exposes_tls_env_vars(self):
+        dockerfile = Path(__file__).parent.parent.parent / "Dockerfile"
+        content = dockerfile.read_text()
+        assert "RECALLLAYER_TLS_CERT" in content
+        assert "RECALLLAYER_TLS_KEY" in content
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-tenancy
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTenancy:
+    def _make_config(self, tenants_str: str):
+        from recalllayer.api.recalllayer_sidecar_app import (
+            SidecarAppConfig,
+            _parse_tenants,
+        )
+
+        cfg = SidecarAppConfig(root_dir=".tmp_test_mt")
+        cfg.tenants = _parse_tenants(tenants_str)
+        return cfg
+
+    def test_parse_tenants(self):
+        from recalllayer.api.recalllayer_sidecar_app import _parse_tenants
+
+        tenants = _parse_tenants("keyA:col-a,keyB:col-b")
+        assert len(tenants) == 2
+        assert tenants[0].api_key == "keyA"
+        assert tenants[0].collection_id == "col-a"
+        assert tenants[1].api_key == "keyB"
+        assert tenants[1].collection_id == "col-b"
+
+    def test_parse_tenants_invalid_format(self):
+        from recalllayer.api.recalllayer_sidecar_app import _parse_tenants
+
+        with pytest.raises(ValueError, match="api_key:collection_id"):
+            _parse_tenants("bad-entry-no-colon")
+
+    def test_each_tenant_gets_own_sidecar(self, tmp_path):
+        from recalllayer.api.recalllayer_sidecar_app import (
+            SidecarAppConfig,
+            _parse_tenants,
+            create_recalllayer_sidecar_app,
+        )
+
+        cfg = SidecarAppConfig(root_dir=str(tmp_path))
+        cfg.tenants = _parse_tenants("key1:col-1,key2:col-2")
+        cfg.auto_flush_interval_sec = 0  # disable scheduler for test
+
+        app = create_recalllayer_sidecar_app(config=cfg)
+        tenant_sidecars = app.state.tenant_sidecars
+
+        assert "key1" in tenant_sidecars
+        assert "key2" in tenant_sidecars
+        # Each tenant has a distinct sidecar pointing at a distinct collection
+        assert tenant_sidecars["key1"] is not tenant_sidecars["key2"]
+        assert tenant_sidecars["key1"].collection_id == "col-1"
+        assert tenant_sidecars["key2"].collection_id == "col-2"
+
+    @pytest.mark.anyio
+    async def test_missing_api_key_rejected_in_multi_tenant_mode(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        from recalllayer.api.recalllayer_sidecar_app import (
+            SidecarAppConfig,
+            _parse_tenants,
+            create_recalllayer_sidecar_app,
+        )
+
+        cfg = SidecarAppConfig(root_dir=str(tmp_path))
+        cfg.tenants = _parse_tenants("secretkey:my-collection")
+        cfg.auto_flush_interval_sec = 0
+
+        app = create_recalllayer_sidecar_app(config=cfg)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.put(
+                "/v1/documents/doc1",
+                json={"title": "t", "body": "b", "region": "us", "status": "published"},
+            )
+        assert resp.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_valid_api_key_accepted_in_multi_tenant_mode(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        from recalllayer.api.recalllayer_sidecar_app import (
+            SidecarAppConfig,
+            _parse_tenants,
+            create_recalllayer_sidecar_app,
+        )
+
+        cfg = SidecarAppConfig(root_dir=str(tmp_path))
+        cfg.tenants = _parse_tenants("secretkey:my-collection")
+        cfg.auto_flush_interval_sec = 0
+
+        app = create_recalllayer_sidecar_app(config=cfg)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.put(
+                "/v1/documents/doc1",
+                json={"title": "t", "body": "b", "region": "us", "status": "published"},
+                headers={"x-api-key": "secretkey"},
+            )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 4. Auto-flush scheduler
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFlushScheduler:
+    def test_scheduler_flushes_on_interval(self, tmp_path):
+        """Scheduler calls flush within a short interval when buffer is non-empty."""
+        from recalllayer.api.recalllayer_sidecar_app import AutoFlushScheduler
+        from recalllayer.sidecar import InMemoryPostgresRepository, RecallLayerSidecar
+
+        sidecar = RecallLayerSidecar(
+            host_db=InMemoryPostgresRepository(),
+            root_dir=tmp_path,
+            collection_id="auto-flush-test",
+        )
+        # Pre-populate the mutable buffer so there is something to flush
+        sidecar.upsert_and_sync_document(
+            document_id="d1", title="Hello", body="World", region="us"
+        )
+
+        buf_before = sum(
+            len(buf.all_entries())
+            for buf in sidecar.recall_layer._shard_buffers.values()
+        )
+        assert buf_before > 0
+
+        scheduler = AutoFlushScheduler(
+            sidecars={"auto-flush-test": sidecar},
+            interval_sec=0.05,  # very short for test
+            upsert_threshold=999_999,  # threshold won't trigger
+            poll_sec=0.02,
+        )
+        scheduler.start()
+        time.sleep(0.3)
+        scheduler.stop()
+
+        buf_after = sum(
+            len(buf.all_entries())
+            for buf in sidecar.recall_layer._shard_buffers.values()
+        )
+        assert buf_after == 0, "buffer should have been flushed by the scheduler"
+
+    def test_scheduler_flushes_on_threshold(self, tmp_path):
+        """Scheduler flushes when upsert_threshold is reached before interval."""
+        from recalllayer.api.recalllayer_sidecar_app import AutoFlushScheduler
+        from recalllayer.sidecar import InMemoryPostgresRepository, RecallLayerSidecar
+
+        sidecar = RecallLayerSidecar(
+            host_db=InMemoryPostgresRepository(),
+            root_dir=tmp_path,
+            collection_id="threshold-flush-test",
+        )
+        sidecar.upsert_and_sync_document(
+            document_id="d1", title="A", body="B", region="us"
+        )
+
+        scheduler = AutoFlushScheduler(
+            sidecars={"threshold-flush-test": sidecar},
+            interval_sec=3600.0,  # very long — won't trigger by time
+            upsert_threshold=1,  # trigger immediately
+            poll_sec=0.02,
+        )
+        scheduler.start()
+        time.sleep(0.3)
+        scheduler.stop()
+
+        buf_after = sum(
+            len(buf.all_entries())
+            for buf in sidecar.recall_layer._shard_buffers.values()
+        )
+        assert buf_after == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Dynamic IVF
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicIVF:
+    def test_ivf_disabled_below_threshold(self, tmp_path):
+        from recalllayer.engine.local_db import LocalVectorDatabase
+
+        db = LocalVectorDatabase(
+            collection_id="ivf-test",
+            root_dir=tmp_path,
+            ivf_auto_threshold=100,
+        )
+        # Only 5 vectors — well below threshold
+        for i in range(5):
+            db.upsert(vector_id=f"v{i}", embedding=[float(i)] * 4)
+
+        result = db._resolve_ivf_clusters(shard_id="shard-0")
+        assert result is None, "IVF should be disabled below threshold"
+
+    def test_ivf_enabled_above_threshold(self, tmp_path):
+        from recalllayer.engine.local_db import LocalVectorDatabase
+
+        db = LocalVectorDatabase(
+            collection_id="ivf-test-large",
+            root_dir=tmp_path,
+            ivf_auto_threshold=10,
+        )
+        for i in range(20):
+            db.upsert(vector_id=f"v{i}", embedding=[float(i)] * 4)
+
+        result = db._resolve_ivf_clusters(shard_id="shard-0")
+        assert result is not None, "IVF should be enabled above threshold"
+        expected = max(8, min(4096, math.isqrt(20)))
+        assert result == expected
+
+    def test_ivf_clusters_scale_with_corpus(self, tmp_path):
+        from recalllayer.engine.local_db import LocalVectorDatabase
+
+        db = LocalVectorDatabase(
+            collection_id="ivf-scale",
+            root_dir=tmp_path,
+            ivf_auto_threshold=0,  # always on
+        )
+        for i in range(10_000):
+            db.upsert(vector_id=f"v{i}", embedding=[float(i % 128)] * 4)
+
+        result = db._resolve_ivf_clusters(shard_id="shard-0")
+        assert result is not None
+        assert result == max(8, min(4096, math.isqrt(10_000)))  # == 100
+
+    def test_manual_enable_ivf_overrides_auto(self, tmp_path):
+        from recalllayer.engine.local_db import LocalVectorDatabase
+
+        db = LocalVectorDatabase(
+            collection_id="ivf-manual",
+            root_dir=tmp_path,
+            enable_ivf=True,
+            ivf_n_clusters=32,
+            ivf_auto_threshold=999_999,
+        )
+        db.upsert(vector_id="v0", embedding=[1.0, 2.0, 3.0, 4.0])
+        result = db._resolve_ivf_clusters(shard_id="shard-0")
+        assert result == 32, "manual enable_ivf should use the explicit cluster count"


### PR DESCRIPTION
## Summary

Implements the five production-hardening features identified as next steps for RecallLayer:

- **Rate limiting** — `SlidingWindowRateLimiter` in `api/rate_limiter.py` enforces a per-API-key request cap (requests/min). Set `RECALLLAYER_RATE_LIMIT=60` to enable; `0` (default) disables it. Returns `429 Too Many Requests` with a `Retry-After` header when exceeded. No new dependencies — stdlib only.

- **TLS termination** — `docker-entrypoint.sh` passes `--ssl-certfile` / `--ssl-keyfile` to uvicorn when `RECALLLAYER_TLS_CERT` and `RECALLLAYER_TLS_KEY` are set. Leave both empty (default) to run plain HTTP behind a reverse proxy. The Dockerfile `HEALTHCHECK` automatically switches to `https://` when TLS is configured.

- **Multi-tenancy** — Set `RECALLLAYER_TENANTS=key1:collection-a,key2:collection-b` to give each API key its own isolated `RecallLayerSidecar` (separate collection namespace, separate storage path). Falls back to single-tenant `RECALLLAYER_API_KEY` behaviour when `RECALLLAYER_TENANTS` is not set.

- **Auto-flush scheduler** — A daemon background thread (`AutoFlushScheduler`) flushes mutable buffers automatically when either `RECALLLAYER_AUTO_FLUSH_INTERVAL_SEC` seconds have elapsed (default 300) or the buffer grows beyond `RECALLLAYER_AUTO_FLUSH_UPSERT_THRESHOLD` entries (default 10 000). Removes the need to call `/v1/flush` manually.

- **Dynamic IVF** — `LocalVectorDatabase._resolve_ivf_clusters()` auto-enables IVF and sets `n_clusters = max(8, sqrt(N))` once total live rows cross `RECALLLAYER_IVF_AUTO_THRESHOLD` (default 50 000). Manual `enable_ivf=True` still takes precedence. Wired through `RecallLayerSidecar` and the sidecar app config.

## Test plan

- [ ] 17 new unit tests in `tests/unit/test_production_hardening.py` cover all five features
- [ ] Full unit suite passes: `276 passed` (was 259 before this PR)
- [ ] Rate limiter: window expiry, per-key isolation, block-on-exceed
- [ ] TLS: entrypoint script and Dockerfile contain correct env vars
- [ ] Multi-tenancy: tenant isolation, 401 on missing/wrong key, 200 on valid key
- [ ] Auto-flush: flushes on interval trigger and on threshold trigger
- [ ] Dynamic IVF: disabled below threshold, enabled above, scales with `sqrt(N)`, manual override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)